### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What & why
+
+<!-- One or two sentences. What changes, and what problem it solves. -->
+
+## Scope
+
+- [ ] Backend (`backend/`)
+- [ ] Web (`frontend/apps/web`)
+- [ ] Mobile (`frontend/apps/mobile`)
+- [ ] Shared packages / tooling / CI
+
+## Acceptance criteria
+
+<!--
+  Copy the acceptance criteria from the linked issue (or Part of #<US>) and
+  tick only what this PR actually delivers. If a criterion is out of scope,
+  say which follow-up issue covers it.
+-->
+
+- [ ] Every acceptance criterion I ticked in the issue is really implemented on this branch
+
+## Tests
+
+- [ ] I added or updated automated tests for this change
+- [ ] Existing tests still pass locally
+- [ ] No new tests


### PR DESCRIPTION
## What & why

Adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR is pre-filled with a checklist covering scope, acceptance criteria and tests. GitHub only picks the template up from the default branch, so it starts working once this is merged into `main`.

## Scope

- [ ] Backend (`backend/`)
- [ ] Web (`frontend/apps/web`)
- [ ] Mobile (`frontend/apps/mobile`)
- [x] Shared packages / tooling / CI

## Acceptance criteria

- [x] Every acceptance criterion I ticked in the issue is really implemented on this branch

## Tests

- [ ] I added or updated automated tests for this change
- [x] Existing tests still pass locally
- [x] No new tests

Docs-only change, no code paths touched. Pre-commit hooks passed (whitespace, EOF, secrets, large files, merge/case conflicts); Prettier, ESLint and Spotless had no matching files to check.

## Note for the reviewer

The template only pre-fills the PR body — it does not enforce anything. If you want it blocking, a follow-up CI job could fail PRs that leave `Closes #<issue>` empty or the Tests section fully unchecked.