### PR TITLE
feat(mobile): alumni list 

### DIFF
--- a/frontend/apps/mobile/app.json
+++ b/frontend/apps/mobile/app.json
@@ -21,6 +21,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
+      "userInterfaceStyle": "light",
       "package": "com.pkka.app"
     },
     "web": {

--- a/frontend/apps/mobile/app/(tabs)/_layout.tsx
+++ b/frontend/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,12 +1,13 @@
+import { useIsAlumni } from "@/components/auth/require-alumni";
 import { useAuth } from "@/lib/auth-context";
 import { useTheme } from "@react-navigation/native";
 import { Tabs } from "expo-router";
-import { Calendar, Home, LogIn, User } from "lucide-react-native";
+import { Calendar, Home, LogIn, User, Users } from "lucide-react-native";
 
 export default function TabsLayout() {
   const { colors } = useTheme();
   const { user } = useAuth();
-  console.log(user);
+  const isAlumni = useIsAlumni();
 
   return (
     <Tabs
@@ -31,6 +32,15 @@ export default function TabsLayout() {
         options={{
           title: "WYDARZENIA",
           tabBarIcon: ({ color, size }) => <Calendar color={color} size={size} />,
+        }}
+      />
+      <Tabs.Screen
+        name="alumni"
+        options={{
+          title: "ALUMNI",
+          // Verified-alumni only: href:null hides the tab and blocks navigation for everyone else.
+          href: isAlumni ? undefined : null,
+          tabBarIcon: ({ color, size }) => <Users color={color} size={size} />,
         }}
       />
       <Tabs.Screen

--- a/frontend/apps/mobile/app/(tabs)/alumni.tsx
+++ b/frontend/apps/mobile/app/(tabs)/alumni.tsx
@@ -1,0 +1,10 @@
+import { AlumniDirectory } from "@/components/alumni-directory/alumni-directory";
+import { RequireAlumni } from "@/components/auth/require-alumni";
+
+export default function AlumniScreen() {
+  return (
+    <RequireAlumni>
+      <AlumniDirectory />
+    </RequireAlumni>
+  );
+}

--- a/frontend/apps/mobile/app/_layout.tsx
+++ b/frontend/apps/mobile/app/_layout.tsx
@@ -1,6 +1,7 @@
 import "@/global.css";
 import { AuthProvider } from "@/lib/auth-context";
 import { NAV_THEME } from "@/lib/theme";
+import { BottomSheetProvider } from "@/components/ui/bottom-sheet-provider";
 import { ApiError } from "@pkka/api";
 import { ThemeProvider } from "@react-navigation/native";
 import { PortalHost } from "@rn-primitives/portal";
@@ -35,17 +36,20 @@ export default function RootLayout() {
         <QueryClientProvider client={queryClient}>
           <ThemeProvider value={NAV_THEME[colorScheme]}>
             <AuthProvider>
-              <SafeAreaView className="flex-1 bg-background">
-                <Stack>
-                  <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                  <Stack.Screen name="index" options={{ headerShown: false }} />
-                  <Stack.Screen name="events/[id]" options={{ headerShown: false }} />
-                  <Stack.Screen name="application" options={{ headerShown: false }} />
-                  <Stack.Screen name="alumni/profile-edit" options={{ headerShown: false }} />
-                </Stack>
-              </SafeAreaView>
-              <StatusBar style="auto" />
-              <PortalHost />
+              <BottomSheetProvider>
+                <SafeAreaView className="flex-1 bg-background">
+                  <Stack>
+                    <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                    <Stack.Screen name="index" options={{ headerShown: false }} />
+                    <Stack.Screen name="events/[id]" options={{ headerShown: false }} />
+                    <Stack.Screen name="application" options={{ headerShown: false }} />
+                    <Stack.Screen name="alumni/profile-edit" options={{ headerShown: false }} />
+                    <Stack.Screen name="alumni/[id]" options={{ headerShown: false }} />
+                  </Stack>
+                </SafeAreaView>
+                <StatusBar style="auto" />
+                <PortalHost />
+              </BottomSheetProvider>
             </AuthProvider>
           </ThemeProvider>
         </QueryClientProvider>

--- a/frontend/apps/mobile/app/alumni/[id].tsx
+++ b/frontend/apps/mobile/app/alumni/[id].tsx
@@ -1,0 +1,46 @@
+import { AlumniProfileView } from "@/components/alumni/alumni-profile-view";
+import { RequireAlumni, useIsAlumni } from "@/components/auth/require-alumni";
+import { DetailHeader } from "@/components/ui/detail-header";
+import { Text } from "@/components/ui/text";
+import { ApiError, useGetAlumniProfile } from "@pkka/api";
+import { router, useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, ScrollView, View } from "react-native";
+
+export default function AlumnDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const isAlumni = useIsAlumni();
+  // The guard below only redirects once rendered, so skip the request a
+  // non-alumni would just get a 403 for.
+  const { data, isPending, error } = useGetAlumniProfile(id ?? "", {
+    query: { enabled: !!id && isAlumni },
+  });
+  const profile = data?.status === 200 ? data.data : undefined;
+  // Every non-2xx throws out of the mutator, so a missing alumn arrives as an
+  // ApiError rather than a ProblemDetail on `data`; anything else is a real failure.
+  const notFound = error instanceof ApiError && error.status === 404;
+
+  return (
+    <RequireAlumni>
+      <View className="bg-background flex-1">
+        <DetailHeader title="Profil alumna" onBack={() => router.back()} />
+        {isPending ? (
+          <View className="flex-1 items-center justify-center">
+            <ActivityIndicator />
+          </View>
+        ) : profile ? (
+          <ScrollView contentContainerClassName="px-4 py-8">
+            <AlumniProfileView profile={profile} />
+          </ScrollView>
+        ) : (
+          <View className="flex-1 items-center justify-center px-8">
+            <Text className="text-muted-foreground text-center">
+              {notFound
+                ? "Nie znaleziono profilu alumna."
+                : "Nie udało się załadować profilu alumna."}
+            </Text>
+          </View>
+        )}
+      </View>
+    </RequireAlumni>
+  );
+}

--- a/frontend/apps/mobile/components/alumni-directory/alumni-card.tsx
+++ b/frontend/apps/mobile/components/alumni-directory/alumni-card.tsx
@@ -1,0 +1,50 @@
+import { SkillChips } from "@/components/alumni/skill-chips";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { THEME } from "@/lib/theme";
+import type { AlumniListItemResponse } from "@pkka/api";
+import { router } from "expo-router";
+import { UserRound } from "lucide-react-native";
+import { View } from "react-native";
+
+type AlumniCardProps = {
+  alumn: AlumniListItemResponse;
+};
+
+export function AlumniCard({ alumn }: AlumniCardProps) {
+  const name = [alumn.firstName, alumn.lastName].filter(Boolean).join(" ");
+  const hasSubtitle = !!(alumn.currentPosition || alumn.company);
+
+  return (
+    <Card className="gap-4 p-5">
+      <View className="flex-row gap-4">
+        <View className="border-border bg-muted size-16 items-center justify-center overflow-hidden rounded-xl border">
+          <UserRound size={32} color={THEME.light.mutedForeground} strokeWidth={1.5} />
+        </View>
+        <View className="flex-1 gap-1.5">
+          <View className="gap-0.5">
+            <Text className="text-foreground text-base font-bold leading-tight">{name}</Text>
+            {alumn.graduationYear ? (
+              <Text className="text-muted-foreground text-[10px] font-semibold uppercase tracking-widest">
+                Rocznik {alumn.graduationYear}
+              </Text>
+            ) : null}
+            {hasSubtitle ? (
+              <Text className="text-muted-foreground text-sm">
+                {alumn.currentPosition}
+                {alumn.currentPosition && alumn.company ? " @ " : ""}
+                {alumn.company}
+              </Text>
+            ) : null}
+          </View>
+          {alumn.tags.length > 0 ? <SkillChips tags={alumn.tags.slice(0, 3)} /> : null}
+        </View>
+      </View>
+
+      <Button onPress={() => router.push({ pathname: "/alumni/[id]", params: { id: alumn.id } })}>
+        <Text className="font-semibold">Zobacz profil</Text>
+      </Button>
+    </Card>
+  );
+}

--- a/frontend/apps/mobile/components/alumni-directory/alumni-directory.tsx
+++ b/frontend/apps/mobile/components/alumni-directory/alumni-directory.tsx
@@ -1,0 +1,154 @@
+import { AlumniCard } from "@/components/alumni-directory/alumni-card";
+import { FilterSheet } from "@/components/alumni-directory/filter-sheet";
+import { SortSheet } from "@/components/alumni-directory/sort-sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import {
+  countActiveFilters,
+  DEFAULT_SORT,
+  EMPTY_FILTERS,
+  useAlumniDirectory,
+  type AlumniFilters,
+  type SortOption,
+} from "@/lib/alumni-directory";
+import { THEME } from "@/lib/theme";
+import { ArrowUpDown, Search, SlidersHorizontal } from "lucide-react-native";
+import { useCallback, useState } from "react";
+import { ActivityIndicator, FlatList, RefreshControl, View } from "react-native";
+
+type ActiveSheet = "filter" | "sort" | null;
+
+export function AlumniDirectory() {
+  const [query, setQuery] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const [filters, setFilters] = useState<AlumniFilters>(EMPTY_FILTERS);
+  const [sort, setSort] = useState<SortOption>(DEFAULT_SORT);
+  const [sheet, setSheet] = useState<ActiveSheet>(null);
+
+  const { alumni, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useAlumniDirectory({ query, filters, sort });
+
+  const activeCount = countActiveFilters(filters);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  }, [refetch]);
+
+  const onEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <View className="bg-background flex-1">
+      {/* Pinned above the list: keeping the search TextInput out of the FlatList
+          header avoids Android focus loss when results change on each keystroke. */}
+      <View className="gap-4 px-5 pb-4 pt-8">
+        <Text className="text-foreground font-heading text-2xl font-bold uppercase tracking-tight">
+          Katalog Alumnów
+        </Text>
+
+        <View className="justify-center">
+          <View className="absolute bottom-0 left-3 top-0 z-10 justify-center">
+            <Search size={18} color={THEME.light.mutedForeground} />
+          </View>
+          <Input
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Szukaj po nazwisku, firmie..."
+            autoCapitalize="none"
+            className="pl-10"
+          />
+        </View>
+
+        <View className="flex-row gap-3">
+          <Button
+            variant="outline"
+            className="flex-1 active:bg-muted"
+            onPress={() => setSheet("filter")}
+          >
+            <SlidersHorizontal size={16} color={THEME.light.foreground} />
+            <Text className="group-active:text-foreground text-sm font-semibold uppercase tracking-wider">
+              Filtruj
+            </Text>
+            {activeCount > 0 ? (
+              <View className="bg-primary ml-1 size-5 items-center justify-center rounded-full">
+                <Text className="text-primary-foreground text-[11px] font-bold">{activeCount}</Text>
+              </View>
+            ) : null}
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1 active:bg-muted"
+            onPress={() => setSheet("sort")}
+          >
+            <ArrowUpDown size={16} color={THEME.light.foreground} />
+            <Text className="group-active:text-foreground text-sm font-semibold uppercase tracking-wider">
+              Sortuj
+            </Text>
+          </Button>
+        </View>
+      </View>
+
+      <FlatList
+        className="flex-1"
+        data={alumni}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View className="px-5">
+            <AlumniCard alumn={item} />
+          </View>
+        )}
+        ItemSeparatorComponent={() => <View className="h-4" />}
+        contentContainerStyle={{ paddingBottom: 48, paddingTop: 4 }}
+        keyboardShouldPersistTaps="handled"
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <View className="py-6">
+              <ActivityIndicator />
+            </View>
+          ) : null
+        }
+        ListEmptyComponent={
+          <View className="px-5 py-16">
+            {isLoading ? (
+              <ActivityIndicator />
+            ) : (
+              <Text className="text-muted-foreground text-center text-sm">
+                {isError
+                  ? "Nie udało się załadować alumnów."
+                  : "Brak alumnów spełniających kryteria."}
+              </Text>
+            )}
+          </View>
+        }
+      />
+
+      <FilterSheet
+        visible={sheet === "filter"}
+        value={filters}
+        onClose={() => setSheet(null)}
+        onApply={(next) => {
+          setFilters(next);
+          setSheet(null);
+        }}
+      />
+      <SortSheet
+        visible={sheet === "sort"}
+        value={sort}
+        onClose={() => setSheet(null)}
+        onApply={(next) => {
+          setSort(next);
+          setSheet(null);
+        }}
+      />
+    </View>
+  );
+}

--- a/frontend/apps/mobile/components/alumni-directory/filter-sheet.tsx
+++ b/frontend/apps/mobile/components/alumni-directory/filter-sheet.tsx
@@ -1,0 +1,134 @@
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { RangeSlider } from "@/components/ui/range-slider";
+import { SearchMultiSelect, type SelectOption } from "@/components/ui/search-multi-select";
+import { Text } from "@/components/ui/text";
+import { EMPTY_FILTERS, YEAR_MAX, YEAR_MIN, type AlumniFilters } from "@/lib/alumni-directory";
+import { cn } from "@/lib/utils";
+import { useListUserTags } from "@pkka/api";
+import { Check } from "lucide-react-native";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Pressable, View } from "react-native";
+
+type FilterSheetProps = {
+  visible: boolean;
+  value: AlumniFilters;
+  onClose: () => void;
+  onApply: (filters: AlumniFilters) => void;
+};
+
+const SHEET_LIST_MAX_HEIGHT = 216;
+
+function HeaderText({ children }: { children: ReactNode }) {
+  return (
+    <Text className="text-muted-foreground text-[10px] font-semibold uppercase tracking-widest">
+      {children}
+    </Text>
+  );
+}
+
+export function FilterSheet({ visible, value, onClose, onApply }: FilterSheetProps) {
+  const [draft, setDraft] = useState<AlumniFilters>(value);
+  // The sheet keeps its children mounted while closed, so the pickers would
+  // otherwise reopen still holding the previous search text and expanded list.
+  // Bumping this on each open remounts them with fresh internal state.
+  const [openCount, setOpenCount] = useState(0);
+
+  const tagsQuery = useListUserTags();
+  const tagOptions = useMemo<SelectOption[]>(
+    () => (tagsQuery.data?.data ?? []).map((tag) => ({ id: tag.id, label: tag.name })),
+    [tagsQuery.data],
+  );
+
+  useEffect(() => {
+    if (visible) {
+      setDraft(value);
+      setOpenCount((n) => n + 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose}>
+      <Text variant="h3" className="text-2xl font-bold">
+        Filtruj
+      </Text>
+
+      <View className="mt-6 gap-3">
+        <View className="flex-row items-center justify-between">
+          <HeaderText>Rok ukończenia</HeaderText>
+          <Text className="text-foreground text-sm font-semibold">
+            {draft.yearRange[0]} — {draft.yearRange[1]}
+          </Text>
+        </View>
+        <RangeSlider
+          min={YEAR_MIN}
+          max={YEAR_MAX}
+          low={draft.yearRange[0]}
+          high={draft.yearRange[1]}
+          onChange={(low, high) => setDraft((d) => ({ ...d, yearRange: [low, high] }))}
+        />
+        <View className="flex-row justify-between">
+          <Text className="text-muted-foreground text-xs">{YEAR_MIN}</Text>
+          <Text className="text-muted-foreground text-xs">{YEAR_MAX}</Text>
+        </View>
+      </View>
+
+      <View className="mt-6 gap-3">
+        <HeaderText>Umiejętności</HeaderText>
+        {tagsQuery.isPending ? (
+          <Text className="text-muted-foreground text-sm">Ładowanie umiejętności...</Text>
+        ) : tagsQuery.isError ? (
+          <Text className="text-destructive text-sm font-medium">
+            Nie udało się załadować listy umiejętności.
+          </Text>
+        ) : (
+          <SearchMultiSelect
+            key={openCount}
+            options={tagOptions}
+            value={draft.tagIds}
+            onChange={(next) =>
+              setDraft((d) => ({
+                ...d,
+                tagIds: typeof next === "function" ? next(d.tagIds) : next,
+              }))
+            }
+            placeholder="Wyszukaj umiejętności..."
+            listMaxHeight={SHEET_LIST_MAX_HEIGHT}
+            uppercaseChips
+          />
+        )}
+      </View>
+
+      <View className="mt-6 gap-3">
+        <HeaderText>Mentoring</HeaderText>
+        <Pressable
+          role="checkbox"
+          accessibilityState={{ checked: draft.mentorOnly }}
+          accessibilityLabel="Tylko chętni do mentoringu"
+          onPress={() => setDraft((d) => ({ ...d, mentorOnly: !d.mentorOnly }))}
+          className="flex-row items-center gap-3 py-1"
+        >
+          <View
+            className={cn(
+              "size-5 items-center justify-center rounded border-2",
+              draft.mentorOnly ? "border-primary bg-primary" : "border-muted-foreground/40",
+            )}
+          >
+            {draft.mentorOnly ? <Check size={14} color="white" strokeWidth={3} /> : null}
+          </View>
+          <Text className="text-foreground text-base">Tylko chętni do mentoringu</Text>
+        </Pressable>
+      </View>
+
+      <View className="mt-6 gap-3">
+        <Button size="lg" onPress={() => onApply(draft)}>
+          <Text className="font-bold">Zastosuj filtry</Text>
+        </Button>
+        <Pressable onPress={() => setDraft(EMPTY_FILTERS)} className="items-center py-1">
+          <Text className="text-muted-foreground text-sm font-semibold">Wyczyść wszystko</Text>
+        </Pressable>
+      </View>
+    </BottomSheet>
+  );
+}

--- a/frontend/apps/mobile/components/alumni-directory/sort-sheet.tsx
+++ b/frontend/apps/mobile/components/alumni-directory/sort-sheet.tsx
@@ -1,0 +1,71 @@
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { SORT_OPTIONS, type SortOption } from "@/lib/alumni-directory";
+import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
+import { Pressable, View } from "react-native";
+
+type SortSheetProps = {
+  visible: boolean;
+  value: SortOption;
+  onClose: () => void;
+  onApply: (value: SortOption) => void;
+};
+
+export function SortSheet({ visible, value, onClose, onApply }: SortSheetProps) {
+  const [draft, setDraft] = useState<SortOption>(value);
+
+  // Seed the draft from the applied sort only on open (see FilterSheet).
+  useEffect(() => {
+    if (visible) setDraft(value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose}>
+      <View className="gap-1">
+        <Text variant="h3" className="text-2xl font-bold">
+          Sortuj według
+        </Text>
+        <Text className="text-muted-foreground text-sm">
+          Wybierz preferowaną kolejność wyświetlania listy alumnów.
+        </Text>
+      </View>
+
+      <View className="my-4">
+        {SORT_OPTIONS.map((option) => {
+          const selected = draft === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              onPress={() => setDraft(option.value)}
+              role="radio"
+              accessibilityState={{ selected }}
+              className="border-border flex-row items-center justify-between border-b py-4"
+            >
+              <Text className="text-foreground text-base">{option.label}</Text>
+              <View
+                className={cn(
+                  "size-5 items-center justify-center rounded-full border-2",
+                  selected ? "border-primary" : "border-muted-foreground/40",
+                )}
+              >
+                {selected ? <View className="bg-primary size-2.5 rounded-full" /> : null}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View className="gap-3">
+        <Button size="lg" onPress={() => onApply(draft)}>
+          <Text className="font-bold">Zastosuj</Text>
+        </Button>
+        <Pressable onPress={onClose} className="items-center py-1">
+          <Text className="text-muted-foreground text-sm font-semibold">Anuluj</Text>
+        </Pressable>
+      </View>
+    </BottomSheet>
+  );
+}

--- a/frontend/apps/mobile/components/alumni/alumni-profile-view.tsx
+++ b/frontend/apps/mobile/components/alumni/alumni-profile-view.tsx
@@ -3,30 +3,39 @@ import { ProfileHero } from "@/components/alumni/profile-hero";
 import { ProfileSectionCard } from "@/components/alumni/profile-section-card";
 import { SkillChips } from "@/components/alumni/skill-chips";
 import { Text } from "@/components/ui/text";
-import type { ProfileResponse } from "@pkka/api";
 import { THEME } from "@/lib/theme";
+import type { AlumniProfileResponse, ProfileResponse } from "@pkka/api";
 import { Pencil } from "lucide-react-native";
 import { Pressable, View } from "react-native";
 
+/**
+ * The viewer's own profile (`/api/profiles/me`) and another alumn's public profile
+ * (`/api/alumni/{id}`) carry the same fields, so the profile presentation components
+ * accept either. Both null out whatever the owner's visibility settings hide.
+ */
+export type AlumnProfile = ProfileResponse | AlumniProfileResponse;
+
 type AlumniProfileViewProps = {
-  profile: ProfileResponse;
-  onEdit: () => void;
+  profile: AlumnProfile;
+  onEdit?: () => void;
 };
 
 export function AlumniProfileView({ profile, onEdit }: AlumniProfileViewProps) {
   return (
     <View className="gap-6">
-      <Pressable
-        onPress={onEdit}
-        role="button"
-        accessibilityLabel="Edytuj profil"
-        className="border-border active:bg-muted flex-row items-center gap-2 self-start rounded-full border px-3 py-1.5"
-      >
-        <Pencil size={14} color={THEME.light.foreground} />
-        <Text className="text-foreground text-xs font-semibold uppercase tracking-wider">
-          Edytuj profil
-        </Text>
-      </Pressable>
+      {onEdit ? (
+        <Pressable
+          onPress={onEdit}
+          role="button"
+          accessibilityLabel="Edytuj profil"
+          className="border-border active:bg-muted flex-row items-center gap-2 self-start rounded-full border px-3 py-1.5"
+        >
+          <Pencil size={14} color={THEME.light.foreground} />
+          <Text className="text-foreground text-xs font-semibold uppercase tracking-wider">
+            Edytuj profil
+          </Text>
+        </Pressable>
+      ) : null}
 
       <ProfileHero profile={profile} />
       <ContactActions profile={profile} />

--- a/frontend/apps/mobile/components/alumni/contact-actions.tsx
+++ b/frontend/apps/mobile/components/alumni/contact-actions.tsx
@@ -1,52 +1,24 @@
 import { Button } from "@/components/ui/button";
 import { DiscordIcon, GithubIcon, LinkedinIcon } from "@/components/ui/svg-icons";
 import { Text } from "@/components/ui/text";
-import type { ProfileResponse } from "@pkka/api";
+import type { AlumnProfile } from "@/components/alumni/alumni-profile-view";
+import type { ReactNode } from "react";
+import {
+  discordUserIdOf,
+  isHttpsUrl,
+  openDiscordUser,
+  openEmail,
+  openWithFallback,
+} from "@/lib/contact";
 import { THEME } from "@/lib/theme";
-import * as Linking from "expo-linking";
-import * as WebBrowser from "expo-web-browser";
 import { Mail } from "lucide-react-native";
-import { Alert, Pressable, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 type ContactActionsProps = {
-  profile: ProfileResponse;
+  profile: AlumnProfile;
 };
 
-// Profile URLs are user-supplied server data. Never hand a non-https value to
-// Linking.openURL, or a malicious profile could launch arbitrary schemes
-// (tel:, third-party app deep links) on the viewer's device.
-const isHttpsUrl = (url: string) => /^https:\/\//i.test(url);
-const isDiscordId = (id: string) => /^[0-9]{5,32}$/.test(id);
-
-async function openWithFallback(appUrl: string, webUrl: string) {
-  try {
-    await Linking.openURL(appUrl);
-  } catch {
-    // the user doesn't have app installed
-    try {
-      await WebBrowser.openBrowserAsync(webUrl);
-    } catch {
-      // e.g. a browser sheet is already presenting - nothing sensible to do
-    }
-  }
-}
-
-async function openEmail(email: string) {
-  try {
-    await Linking.openURL(`mailto:${email}`);
-  } catch {
-    Alert.alert("Adres e-mail", email);
-  }
-}
-
-async function openDiscord(discordId: string) {
-  await openWithFallback(
-    `discord://-/users/${discordId}`,
-    `https://discord.com/users/${discordId}`,
-  );
-}
-
-function ExternalLink({ label, url, icon }: { label: string; url: string; icon: React.ReactNode }) {
+function ExternalLink({ label, url, icon }: { label: string; url: string; icon: ReactNode }) {
   return (
     <Pressable
       role="link"
@@ -64,10 +36,7 @@ function ExternalLink({ label, url, icon }: { label: string; url: string; icon: 
 
 export function ContactActions({ profile }: ContactActionsProps) {
   const email = profile.visibility.email ? profile.email : undefined;
-  const discordId =
-    profile.visibility.discord && profile.discordId && isDiscordId(profile.discordId)
-      ? profile.discordId
-      : undefined;
+  const discordId = discordUserIdOf(profile);
   const linkedinUrl =
     profile.linkedinUrl && isHttpsUrl(profile.linkedinUrl) ? profile.linkedinUrl : null;
   const githubUrl = profile.githubUrl && isHttpsUrl(profile.githubUrl) ? profile.githubUrl : null;
@@ -81,7 +50,7 @@ export function ContactActions({ profile }: ContactActionsProps) {
       {hasButtons ? (
         <View className="gap-3">
           {discordId ? (
-            <Button size="lg" className="w-full" onPress={() => openDiscord(discordId)}>
+            <Button size="lg" className="w-full" onPress={() => openDiscordUser(discordId)}>
               <DiscordIcon size={18} color={THEME.light.primaryForeground} />
               <Text className="font-bold">Kontakt przez Discord</Text>
             </Button>

--- a/frontend/apps/mobile/components/alumni/profile-hero.tsx
+++ b/frontend/apps/mobile/components/alumni/profile-hero.tsx
@@ -1,12 +1,12 @@
 import { Badge } from "@/components/ui/badge";
 import { Text } from "@/components/ui/text";
-import type { ProfileResponse } from "@pkka/api";
+import type { AlumnProfile } from "@/components/alumni/alumni-profile-view";
 import { THEME } from "@/lib/theme";
 import { HeartHandshake, UserRound } from "lucide-react-native";
 import { View } from "react-native";
 
 type ProfileHeroProps = {
-  profile: ProfileResponse;
+  profile: AlumnProfile;
 };
 
 export function ProfileHero({ profile }: ProfileHeroProps) {

--- a/frontend/apps/mobile/components/alumni/skill-chips.tsx
+++ b/frontend/apps/mobile/components/alumni/skill-chips.tsx
@@ -1,10 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { Text } from "@/components/ui/text";
-import type { TagResponse } from "@pkka/api";
+import type { UserTagResponse } from "@pkka/api";
 import { View } from "react-native";
 
 type SkillChipsProps = {
-  tags: TagResponse[];
+  tags: UserTagResponse[];
 };
 
 export function SkillChips({ tags }: SkillChipsProps) {

--- a/frontend/apps/mobile/components/auth/require-alumni.tsx
+++ b/frontend/apps/mobile/components/auth/require-alumni.tsx
@@ -1,0 +1,14 @@
+import { useAuth } from "@/lib/auth-context";
+import { Redirect } from "expo-router";
+import { type ReactNode } from "react";
+
+export function useIsAlumni() {
+  const { user } = useAuth();
+  return user?.role === "alumni";
+}
+
+export function RequireAlumni({ children }: { children: ReactNode }) {
+  const isAlumni = useIsAlumni();
+  if (!isAlumni) return <Redirect href="/(tabs)" />;
+  return <>{children}</>;
+}

--- a/frontend/apps/mobile/components/ui/bottom-sheet-provider.tsx
+++ b/frontend/apps/mobile/components/ui/bottom-sheet-provider.tsx
@@ -1,0 +1,6 @@
+import { BottomSheetProvider as NativeBottomSheetProvider } from "@swmansion/react-native-bottom-sheet";
+import { type ReactNode } from "react";
+
+export function BottomSheetProvider({ children }: { children: ReactNode }) {
+  return <NativeBottomSheetProvider>{children}</NativeBottomSheetProvider>;
+}

--- a/frontend/apps/mobile/components/ui/bottom-sheet-provider.web.tsx
+++ b/frontend/apps/mobile/components/ui/bottom-sheet-provider.web.tsx
@@ -1,0 +1,7 @@
+import { type ReactNode } from "react";
+
+// The native sheet's portal host has no web counterpart — bottom-sheet.web.tsx
+// renders through a Modal instead, so the provider is a passthrough here.
+export function BottomSheetProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/apps/mobile/components/ui/bottom-sheet.tsx
+++ b/frontend/apps/mobile/components/ui/bottom-sheet.tsx
@@ -1,0 +1,63 @@
+import { THEME } from "@/lib/theme";
+import { ModalBottomSheet } from "@swmansion/react-native-bottom-sheet";
+import { useEffect, useState, type ReactNode } from "react";
+import { StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+type BottomSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+const DETENTS: (number | "content")[] = [0, "content"];
+const SCRIM_OPACITIES = [0, 0.4];
+
+export function BottomSheet({ visible, onClose, children }: BottomSheetProps) {
+  const insets = useSafeAreaInsets();
+  const [index, setIndex] = useState(visible ? 1 : 0);
+
+  useEffect(() => {
+    setIndex(visible ? 1 : 0);
+  }, [visible]);
+
+  return (
+    <ModalBottomSheet
+      detents={DETENTS}
+      index={index}
+      onIndexChange={(next) => {
+        setIndex(next);
+        if (next === 0) onClose();
+      }}
+      scrimColor="#000000"
+      scrimOpacities={SCRIM_OPACITIES}
+      surface={
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              backgroundColor: THEME.light.background,
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+            },
+          ]}
+        />
+      }
+    >
+      <View style={{ paddingHorizontal: 20, paddingTop: 12, paddingBottom: insets.bottom + 24 }}>
+        <View
+          style={{
+            alignSelf: "center",
+            width: 48,
+            height: 5,
+            borderRadius: 999,
+            backgroundColor: THEME.light.mutedForeground,
+            opacity: 0.3,
+            marginBottom: 16,
+          }}
+        />
+        {children}
+      </View>
+    </ModalBottomSheet>
+  );
+}

--- a/frontend/apps/mobile/components/ui/bottom-sheet.web.tsx
+++ b/frontend/apps/mobile/components/ui/bottom-sheet.web.tsx
@@ -1,0 +1,49 @@
+import { THEME } from "@/lib/theme";
+import { type ReactNode } from "react";
+import { Modal, Pressable, View } from "react-native";
+
+type BottomSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+// @swmansion/react-native-bottom-sheet is a Fabric component and calls
+// codegenNativeComponent, which does not exist on web — importing it breaks the
+// `expo export --platform web` bundle. Web gets this Modal-based equivalent instead.
+export function BottomSheet({ visible, onClose, children }: BottomSheetProps) {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable
+        accessibilityLabel="Zamknij"
+        onPress={onClose}
+        style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.4)", justifyContent: "flex-end" }}
+      >
+        <Pressable
+          onPress={(e) => e.stopPropagation()}
+          style={{
+            backgroundColor: THEME.light.background,
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            paddingHorizontal: 20,
+            paddingTop: 12,
+            paddingBottom: 24,
+          }}
+        >
+          <View
+            style={{
+              alignSelf: "center",
+              width: 48,
+              height: 5,
+              borderRadius: 999,
+              backgroundColor: THEME.light.mutedForeground,
+              opacity: 0.3,
+              marginBottom: 16,
+            }}
+          />
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/frontend/apps/mobile/components/ui/range-slider.tsx
+++ b/frontend/apps/mobile/components/ui/range-slider.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useRef, useState } from "react";
+import { PanResponder, View } from "react-native";
+
+const THUMB = 24;
+
+type RangeSliderProps = {
+  min: number;
+  max: number;
+  low: number;
+  high: number;
+  step?: number;
+  onChange: (low: number, high: number) => void;
+};
+
+// Dual-thumb range slider driven by PanResponder
+export function RangeSlider({ min, max, low, high, step = 1, onChange }: RangeSliderProps) {
+  const [width, setWidth] = useState(0);
+  const usable = Math.max(width - THUMB, 1);
+
+  // Refs keep the responder closures reading the latest props without being
+  // recreated mid-gesture.
+  const lowRef = useRef(low);
+  const highRef = useRef(high);
+  const onChangeRef = useRef(onChange);
+  lowRef.current = low;
+  highRef.current = high;
+  onChangeRef.current = onChange;
+  const startXRef = useRef(0);
+
+  const valueToX = (value: number) => ((value - min) / (max - min)) * usable;
+  const xToValue = (x: number) => {
+    const ratio = Math.min(Math.max(x / usable, 0), 1);
+    return Math.round((min + ratio * (max - min)) / step) * step;
+  };
+
+  const responders = useMemo(() => {
+    const make = (which: "low" | "high") =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        // Keep the pan once it starts — otherwise the enclosing native bottom
+        // sheet's drag-to-dismiss can steal a thumb drag that has any vertical drift.
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: () => {
+          startXRef.current = valueToX(which === "low" ? lowRef.current : highRef.current);
+        },
+        onPanResponderMove: (_evt, gesture) => {
+          const next = xToValue(startXRef.current + gesture.dx);
+          if (which === "low") {
+            onChangeRef.current(Math.min(next, highRef.current), highRef.current);
+          } else {
+            onChangeRef.current(lowRef.current, Math.max(next, lowRef.current));
+          }
+        },
+      });
+    return { low: make("low"), high: make("high") };
+    // valueToX/xToValue close over `usable`, so rebuild the responders when it changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [usable]);
+
+  return (
+    <View className="py-2" onLayout={(e) => setWidth(e.nativeEvent.layout.width)}>
+      <View className="h-6 justify-center">
+        <View className="bg-muted h-1 rounded-full" />
+        {width > 0 ? (
+          <>
+            <View
+              className="bg-foreground absolute h-1 rounded-full"
+              style={{
+                left: valueToX(low) + THUMB / 2,
+                width: Math.max(valueToX(high) - valueToX(low), 0),
+              }}
+            />
+            <View
+              {...responders.low.panHandlers}
+              hitSlop={12}
+              className="border-foreground bg-background absolute size-6 rounded-full border-2"
+              // When both thumbs sit at max, lift the low thumb above the high
+              // thumb so it stays grabbable (only the low thumb can still move).
+              style={{ left: valueToX(low), zIndex: low === max ? 2 : 1 }}
+            />
+            <View
+              {...responders.high.panHandlers}
+              hitSlop={12}
+              className="border-foreground bg-background absolute size-6 rounded-full border-2"
+              style={{ left: valueToX(high), zIndex: 1 }}
+            />
+          </>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/frontend/apps/mobile/components/ui/search-multi-select.tsx
+++ b/frontend/apps/mobile/components/ui/search-multi-select.tsx
@@ -1,0 +1,191 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { THEME } from "@/lib/theme";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react-native";
+import { useMemo, useRef, useState } from "react";
+import { Keyboard, Pressable, ScrollView, TextInput, View } from "react-native";
+
+// Caps the open dropdown so a long option list stays scrollable instead of
+// pushing the rest of the form (or sheet) off-screen.
+const LIST_MAX_HEIGHT = 288;
+
+export type SelectOption = {
+  id: string;
+  label: string;
+};
+
+type SearchMultiSelectProps = {
+  options: SelectOption[];
+  /** Selected option ids. */
+  value: string[];
+  onChange: (next: string[] | ((prev: string[]) => string[])) => void;
+  placeholder: string;
+  /** Upper bound on selections; omit for unlimited. */
+  max?: number;
+  /** Shown once `max` selections are reached. */
+  maxHint?: string;
+  emptyText?: string;
+  listMaxHeight?: number;
+  /** Uppercase the selected chips, as the profile form does for skills. */
+  uppercaseChips?: boolean;
+};
+
+/**
+ * Searchable multi-select: selected values as removable chips above a search
+ * field that opens a scrollable, checkable option list. Used wherever the option
+ * set can grow past what a flat wall of chips can show — skills, companies.
+ */
+export function SearchMultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+  max,
+  maxHint,
+  emptyText = "Brak wyników.",
+  listMaxHeight = LIST_MAX_HEIGHT,
+  uppercaseChips = false,
+}: SearchMultiSelectProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<TextInput>(null);
+
+  const selected = useMemo(
+    () => options.filter((option) => value.includes(option.id)),
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return needle
+      ? options.filter((option) => option.label.toLowerCase().includes(needle))
+      : options;
+  }, [options, query]);
+
+  const atMax = max !== undefined && value.length >= max;
+
+  // Compute from `prev` (the freshest value) rather than the captured `value`
+  // prop, so a memoized onPress closure can never act on a stale snapshot.
+  const toggle = (id: string) => {
+    onChange((prev) => {
+      if (prev.includes(id)) return prev.filter((optionId) => optionId !== id);
+      if (max !== undefined && prev.length >= max) return prev;
+      return [...prev, id];
+    });
+  };
+
+  // Collapse resets the search so the field shows a clean placeholder again.
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+    Keyboard.dismiss();
+  };
+
+  return (
+    <View className="gap-3">
+      {selected.length > 0 ? (
+        <View className="flex-row flex-wrap gap-2">
+          {selected.map((option) => (
+            <Pressable
+              key={option.id}
+              onPress={() => toggle(option.id)}
+              accessibilityLabel={`Usuń: ${option.label}`}
+              className="bg-muted flex-row items-center gap-1 rounded-md px-3 py-1.5 active:opacity-70"
+            >
+              <Text className="text-foreground text-xs font-semibold">
+                {uppercaseChips ? option.label.toUpperCase() : option.label}
+              </Text>
+              <X size={12} color={THEME.light.mutedForeground} />
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
+      <View className="relative justify-center">
+        <View pointerEvents="none" className="absolute left-3 z-10">
+          <Search size={18} color={THEME.light.mutedForeground} />
+        </View>
+        <Input
+          ref={inputRef}
+          value={query}
+          onChangeText={setQuery}
+          onFocus={() => setOpen(true)}
+          onBlur={close}
+          placeholder={placeholder}
+          autoCapitalize="none"
+          autoCorrect={false}
+          className="pl-10 pr-10"
+        />
+        <Pressable
+          onPress={() => {
+            if (query) {
+              setQuery("");
+              inputRef.current?.focus();
+            } else if (open) {
+              close();
+            } else {
+              inputRef.current?.focus();
+            }
+          }}
+          accessibilityLabel={
+            query ? "Wyczyść wyszukiwanie" : open ? "Zamknij listę" : "Otwórz listę"
+          }
+          className="absolute right-2 h-8 w-8 items-center justify-center rounded-full active:bg-muted"
+        >
+          {query ? (
+            <X size={18} color={THEME.light.mutedForeground} />
+          ) : open ? (
+            <ChevronUp size={18} color={THEME.light.mutedForeground} />
+          ) : (
+            <ChevronDown size={18} color={THEME.light.mutedForeground} />
+          )}
+        </Pressable>
+      </View>
+
+      {atMax && maxHint ? <Text className="text-muted-foreground text-xs">{maxHint}</Text> : null}
+
+      {open ? (
+        filtered.length === 0 ? (
+          <View className="border-border rounded-md border px-3 py-4">
+            <Text className="text-muted-foreground text-sm">{emptyText}</Text>
+          </View>
+        ) : (
+          <View className="border-border overflow-hidden rounded-md border">
+            <ScrollView
+              style={{ maxHeight: listMaxHeight }}
+              keyboardShouldPersistTaps="handled"
+              nestedScrollEnabled
+            >
+              {filtered.map((option, index) => {
+                const isSelected = value.includes(option.id);
+                const disabled = atMax && !isSelected;
+                return (
+                  <Pressable
+                    key={option.id}
+                    onPress={() => toggle(option.id)}
+                    disabled={disabled}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: isSelected, disabled }}
+                    className={cn(
+                      "flex-row items-center gap-3 px-3 py-3",
+                      index > 0 && "border-border border-t",
+                      isSelected && "bg-muted/40",
+                      disabled && "opacity-40",
+                    )}
+                  >
+                    <View pointerEvents="none">
+                      <Checkbox checked={isSelected} onCheckedChange={() => {}} />
+                    </View>
+                    <Text className="text-foreground flex-1 text-sm">{option.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+        )
+      ) : null}
+    </View>
+  );
+}

--- a/frontend/apps/mobile/lib/alumni-directory.ts
+++ b/frontend/apps/mobile/lib/alumni-directory.ts
@@ -1,0 +1,112 @@
+import { useDebouncedValue } from "@/lib/use-debounced-value";
+import {
+  useListAlumniInfinite,
+  type AlumniListItemResponse,
+  type ListAlumniParams,
+} from "@pkka/api";
+import { useMemo } from "react";
+
+export const YEAR_MIN = 1970;
+export const YEAR_MAX = new Date().getFullYear();
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export type SortOption = "name-asc" | "name-desc" | "grad-desc" | "grad-asc";
+
+export const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "name-asc", label: "Nazwisko (A-Z)" },
+  { value: "name-desc", label: "Nazwisko (Z-A)" },
+  { value: "grad-desc", label: "Rok ukończenia (Najnowsze)" },
+  { value: "grad-asc", label: "Rok ukończenia (Najstarsze)" },
+];
+
+// Spring Data `sort` values; the properties are columns of `users`, so both
+// lastName and graduationYear are sortable server-side.
+const SORT_PARAM: Record<SortOption, string> = {
+  "name-asc": "lastName,asc",
+  "name-desc": "lastName,desc",
+  "grad-desc": "graduationYear,desc",
+  "grad-asc": "graduationYear,asc",
+};
+
+export const DEFAULT_SORT: SortOption = "name-asc";
+
+export type AlumniFilters = {
+  yearRange: [number, number];
+  tagIds: string[];
+  mentorOnly: boolean;
+};
+
+export const EMPTY_FILTERS: AlumniFilters = {
+  yearRange: [YEAR_MIN, YEAR_MAX],
+  tagIds: [],
+  mentorOnly: false,
+};
+
+export function buildAlumniParams(
+  query: string,
+  filters: AlumniFilters,
+  sort: SortOption,
+): ListAlumniParams {
+  const trimmedQuery = query.trim();
+  const [lowYear, highYear] = filters.yearRange;
+
+  return {
+    size: PAGE_SIZE,
+    sort: [SORT_PARAM[sort]],
+    ...(trimmedQuery ? { q: trimmedQuery } : {}),
+    ...(filters.tagIds.length > 0 ? { tagIds: filters.tagIds } : {}),
+    ...(filters.mentorOnly ? { mentor: true } : {}),
+    ...(lowYear > YEAR_MIN ? { graduationYearFrom: lowYear } : {}),
+    ...(highYear < YEAR_MAX ? { graduationYearTo: highYear } : {}),
+  };
+}
+
+type UseAlumniDirectoryArgs = {
+  query: string;
+  filters: AlumniFilters;
+  sort: SortOption;
+};
+
+export function useAlumniDirectory({ query, filters, sort }: UseAlumniDirectoryArgs) {
+  const debouncedQuery = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
+  const params = buildAlumniParams(debouncedQuery, filters, sort);
+
+  const result = useListAlumniInfinite(params, {
+    query: {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.status !== 200) return undefined;
+        const page = lastPage.data;
+        const next = (page.number ?? 0) + 1;
+        return next < (page.totalPages ?? 0) ? next : undefined;
+      },
+    },
+  });
+
+  const alumni = useMemo<AlumniListItemResponse[]>(
+    () =>
+      result.data?.pages.flatMap((page) =>
+        page.status === 200 ? (page.data.content ?? []) : [],
+      ) ?? [],
+    [result.data],
+  );
+
+  return {
+    alumni,
+    isLoading: result.isPending,
+    isError: result.isError,
+    refetch: result.refetch,
+    fetchNextPage: result.fetchNextPage,
+    hasNextPage: result.hasNextPage,
+    isFetchingNextPage: result.isFetchingNextPage,
+  };
+}
+
+export function countActiveFilters(filters: AlumniFilters): number {
+  let count = filters.tagIds.length;
+  if (filters.mentorOnly) count += 1;
+  if (filters.yearRange[0] !== YEAR_MIN || filters.yearRange[1] !== YEAR_MAX) count += 1;
+  return count;
+}

--- a/frontend/apps/mobile/lib/auth-context.tsx
+++ b/frontend/apps/mobile/lib/auth-context.tsx
@@ -1,8 +1,9 @@
+import { isVerifiedAlumn } from "@/lib/roles";
 import { AuthContextType, User } from "@/types/auth";
 import { configureApi, logoutTokens, refreshTokens } from "@pkka/api";
 import * as SecureStore from "expo-secure-store";
 import { jwtDecode } from "jwt-decode";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { AppState } from "react-native";
 
 export const AuthContext = createContext<null | AuthContextType>(null);
@@ -14,15 +15,15 @@ type decodedJwtType = {
   };
 };
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
 
   const login = async (at: string, rt: string) => {
     const decoded = jwtDecode(at) as decodedJwtType;
-    console.warn("login run!");
+    const roles = decoded["realm_access"]?.["roles"] ?? [];
     setUser({
       sub: decoded["sub"],
-      role: decoded["realm_access"]["roles"].includes("alumni") ? "alumni" : "user",
+      role: isVerifiedAlumn(roles) ? "alumni" : "user",
     });
 
     await SecureStore.setItemAsync("at", at);

--- a/frontend/apps/mobile/lib/contact.ts
+++ b/frontend/apps/mobile/lib/contact.ts
@@ -1,0 +1,44 @@
+import type { AlumnProfile } from "@/components/alumni/alumni-profile-view";
+import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
+import { Alert } from "react-native";
+
+// Profile URLs are user-supplied server data. Never hand a non-https URL to
+// Linking.openURL, or a malicious profile could launch arbitrary schemes
+// (tel:, third-party app deep links) on the viewer's device.
+export const isHttpsUrl = (url: string) => /^https:\/\//i.test(url);
+export const isDiscordId = (id: string) => /^[0-9]{5,32}$/.test(id);
+
+export async function openWithFallback(appUrl: string, webUrl: string) {
+  try {
+    await Linking.openURL(appUrl);
+  } catch {
+    // the user doesn't have the app installed
+    try {
+      await WebBrowser.openBrowserAsync(webUrl);
+    } catch {
+      // e.g. a browser sheet is already presenting - nothing sensible to do
+    }
+  }
+}
+
+export async function openEmail(email: string) {
+  try {
+    await Linking.openURL(`mailto:${email}`);
+  } catch {
+    Alert.alert("Adres e-mail", email);
+  }
+}
+
+export function discordUserIdOf(profile: AlumnProfile): string | null {
+  return profile.visibility.discord && profile.discordId && isDiscordId(profile.discordId)
+    ? profile.discordId
+    : null;
+}
+
+export function openDiscordUser(discordId: string) {
+  return openWithFallback(
+    `discord://-/users/${discordId}`,
+    `https://discord.com/users/${discordId}`,
+  );
+}

--- a/frontend/apps/mobile/lib/roles.ts
+++ b/frontend/apps/mobile/lib/roles.ts
@@ -1,15 +1,9 @@
-// Keycloak realm roles, mirrored from the web app's lib/roles.ts. Roles are
-// normalized (lowercased, `_` → `-`) before comparison so `verified_alumn`,
-// `VERIFIED-ALUMN`, etc. all match the same role.
+// Roles as returned by /api/me: Spring format, ROLE_ prefix stripped.
 
-export const VERIFIED_ALUMN_ROLE = "verified-alumn";
-
-const normalize = (role: string) => role.toLowerCase().replace(/_/g, "-");
+export const VERIFIED_ALUMN_ROLE = "VERIFIED_ALUMN";
 
 export function hasRole(roles: string[] | undefined | null, role: string) {
-  if (!roles) return false;
-  const target = normalize(role);
-  return roles.some((r) => normalize(r) === target);
+  return roles?.includes(role) ?? false;
 }
 
 export function isVerifiedAlumn(roles: string[] | undefined | null) {

--- a/frontend/apps/mobile/lib/roles.ts
+++ b/frontend/apps/mobile/lib/roles.ts
@@ -1,0 +1,17 @@
+// Keycloak realm roles, mirrored from the web app's lib/roles.ts. Roles are
+// normalized (lowercased, `_` → `-`) before comparison so `verified_alumn`,
+// `VERIFIED-ALUMN`, etc. all match the same role.
+
+export const VERIFIED_ALUMN_ROLE = "verified-alumn";
+
+const normalize = (role: string) => role.toLowerCase().replace(/_/g, "-");
+
+export function hasRole(roles: string[] | undefined | null, role: string) {
+  if (!roles) return false;
+  const target = normalize(role);
+  return roles.some((r) => normalize(r) === target);
+}
+
+export function isVerifiedAlumn(roles: string[] | undefined | null) {
+  return hasRole(roles, VERIFIED_ALUMN_ROLE);
+}

--- a/frontend/apps/mobile/lib/use-debounced-value.ts
+++ b/frontend/apps/mobile/lib/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/frontend/apps/mobile/package.json
+++ b/frontend/apps/mobile/package.json
@@ -27,6 +27,7 @@
     "@rn-primitives/slot": "^1.4.0",
     "@rn-primitives/toggle": "1.4.0",
     "@rn-primitives/toggle-group": "1.4.0",
+    "@swmansion/react-native-bottom-sheet": "0.16.2",
     "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",
@@ -65,7 +66,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "babel-preset-expo": "^55.0.21",
+    "babel-preset-expo": "^54.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
     "prettier-plugin-tailwindcss": "^0.5.14",

--- a/frontend/apps/web/lib/roles.ts
+++ b/frontend/apps/web/lib/roles.ts
@@ -1,12 +1,10 @@
-export const ADMIN_ROLE = "admin";
-export const VERIFIED_ALUMN_ROLE = "verified-alumn";
+// Roles as returned by /api/me: Spring format, ROLE_ prefix stripped.
 
-function normalizeRole(role: string): string {
-  return role.toLowerCase().replace(/_/g, "-");
-}
+export const ADMIN_ROLE = "ADMIN";
+export const VERIFIED_ALUMN_ROLE = "VERIFIED_ALUMN";
 
 export function hasRole(roles: string[] | undefined | null, role: string): boolean {
-  return (roles ?? []).map(normalizeRole).includes(normalizeRole(role));
+  return roles?.includes(role) ?? false;
 }
 
 export function isAdmin(roles: string[] | undefined | null): boolean {

--- a/frontend/packages/api/orval.config.ts
+++ b/frontend/packages/api/orval.config.ts
@@ -25,6 +25,11 @@ export default defineConfig({
       override: {
         mutator: { path: "./mutator.ts", name: "apiFetch" },
         query: { useQuery: true, useMutation: true, signal: true, usePrefetch: true },
+        operations: {
+          listAlumni: {
+            query: { useInfinite: true, useInfiniteQueryParam: "page" },
+          },
+        },
       },
       formatter: "prettier",
     },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@rn-primitives/toggle-group':
         specifier: 1.4.0
         version: 1.4.0(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@swmansion/react-native-bottom-sheet':
+        specifier: 0.16.2
+        version: 0.16.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@tanstack/react-form':
         specifier: ^1.33.0
         version: 1.33.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -180,8 +183,8 @@ importers:
         specifier: ~19.1.0
         version: 19.1.17
       babel-preset-expo:
-        specifier: ^55.0.21
-        version: 55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2)
+        specifier: ^54.0.10
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2)
       eslint:
         specifier: ^9.25.0
         version: 9.39.4(jiti@1.21.7)
@@ -2622,30 +2625,14 @@ packages:
     resolution: {integrity: sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==}
     engines: {node: '>= 20.19.4'}
 
-  '@react-native/babel-plugin-codegen@0.83.6':
-    resolution: {integrity: sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==}
-    engines: {node: '>= 20.19.4'}
-
   '@react-native/babel-preset@0.81.5':
     resolution: {integrity: sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
 
-  '@react-native/babel-preset@0.83.6':
-    resolution: {integrity: sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==}
-    engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
-
   '@react-native/codegen@0.81.5':
     resolution: {integrity: sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==}
-    engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
-
-  '@react-native/codegen@0.83.6':
-    resolution: {integrity: sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
@@ -2948,6 +2935,12 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swmansion/react-native-bottom-sheet@0.16.2':
+    resolution: {integrity: sha512-E4PnJxM6q/L6Y5zaugGhGx+ObkbuoNmF8LLSbKAyBUkcE2Cn8/estH1GVYxJYMxQwYVz7RY4GZ9ownlAcGLJUg==}
+    peerDependencies:
+      react: 19.1.0
+      react-native: '>=0.76.0'
 
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
@@ -3576,12 +3569,6 @@ packages:
   babel-plugin-syntax-hermes-parser@0.29.1:
     resolution: {integrity: sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==}
 
-  babel-plugin-syntax-hermes-parser@0.32.0:
-    resolution: {integrity: sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==}
-
-  babel-plugin-syntax-hermes-parser@0.32.1:
-    resolution: {integrity: sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==}
-
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
 
@@ -3600,21 +3587,6 @@ packages:
       '@babel/runtime':
         optional: true
       expo:
-        optional: true
-
-  babel-preset-expo@55.0.21:
-    resolution: {integrity: sha512-anXoUZBcxydLdVs2L+r3bWKGUvZv2FtgOl8xRJ12i/YfKICBpwTGZWSTiEYTqBByZ6GkA3mE9+3TW97X2ocFTQ==}
-    peerDependencies:
-      '@babel/runtime': ^7.20.0
-      expo: '*'
-      expo-widgets: ^55.0.17
-      react-refresh: '>=0.14.0 <1.0.0'
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-      expo:
-        optional: true
-      expo-widgets:
         optional: true
 
   babel-preset-jest@29.6.3:
@@ -4887,9 +4859,6 @@ packages:
   hermes-estree@0.32.0:
     resolution: {integrity: sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==}
 
-  hermes-estree@0.32.1:
-    resolution: {integrity: sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==}
-
   hermes-estree@0.35.0:
     resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
 
@@ -4901,9 +4870,6 @@ packages:
 
   hermes-parser@0.32.0:
     resolution: {integrity: sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==}
-
-  hermes-parser@0.32.1:
-    resolution: {integrity: sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==}
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
@@ -10184,14 +10150,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@react-native/babel-plugin-codegen@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@react-native/codegen': 0.83.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   '@react-native/babel-preset@0.81.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -10242,72 +10200,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/babel-preset@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/template': 7.28.6
-      '@react-native/babel-plugin-codegen': 0.83.6(@babel/core@7.29.0)
-      babel-plugin-syntax-hermes-parser: 0.32.0
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@react-native/codegen@0.81.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.3
       glob: 7.2.3
       hermes-parser: 0.29.1
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      yargs: 17.7.2
-
-  '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
-      glob: 7.2.3
-      hermes-parser: 0.32.0
       invariant: 2.2.4
       nullthrows: 1.1.1
       yargs: 17.7.2
@@ -10639,6 +10537,11 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swmansion/react-native-bottom-sheet@0.16.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   '@tailwindcss/node@4.2.4':
     dependencies:
@@ -11310,14 +11213,6 @@ snapshots:
     dependencies:
       hermes-parser: 0.29.1
 
-  babel-plugin-syntax-hermes-parser@0.32.0:
-    dependencies:
-      hermes-parser: 0.32.0
-
-  babel-plugin-syntax-hermes-parser@0.32.1:
-    dependencies:
-      hermes-parser: 0.32.1
-
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
@@ -11364,39 +11259,6 @@ snapshots:
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  babel-preset-expo@55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/babel-preset': 0.83.6(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.32.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
       debug: 4.4.3
       react-refresh: 0.14.2
@@ -12079,8 +11941,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -12102,21 +11964,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -12132,6 +11979,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
@@ -12143,14 +12005,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12192,7 +12054,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12203,7 +12065,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13033,8 +12895,6 @@ snapshots:
 
   hermes-estree@0.32.0: {}
 
-  hermes-estree@0.32.1: {}
-
   hermes-estree@0.35.0: {}
 
   hermes-parser@0.25.1:
@@ -13048,10 +12908,6 @@ snapshots:
   hermes-parser@0.32.0:
     dependencies:
       hermes-estree: 0.32.0
-
-  hermes-parser@0.32.1:
-    dependencies:
-      hermes-estree: 0.32.1
 
   hermes-parser@0.35.0:
     dependencies:


### PR DESCRIPTION
## What & why

Adds the mobile alumni directory, replacing the previously mocked data with the real `/api/alumni` endpoints.

- New **ALUMNI** tab with an infinite-scroll list (`useListAlumniInfinite`, 20/page), debounced search, and empty/error states.
- **Filter sheet** — graduation-year range, skill tags (OR semantics), mentors-only — and a **sort sheet** (surname / graduation year, both directions).
- **Alumn detail screen** (`/alumni/[id]`) reusing the existing profile view, with contact actions: Discord deep link with web fallback, `mailto:`, and LinkedIn/GitHub links.
- Access is verified-alumni only: the tab is hidden via `href: null`, and `RequireAlumni` additionally guards the routes so a deep link can't reach an alumn's contact details.
- Supporting UI primitives: a native detents-based `BottomSheet` (on `@swmansion/react-native-bottom-sheet`, which works on New Arch + Reanimated 4 where `@gorhom/bottom-sheet` silently no-ops), plus reusable `RangeSlider` and `SearchMultiSelect`.

Profile URLs are user-supplied server data, so they're validated as `https` before being handed to `Linking.openURL` rather than allowing arbitrary schemes (`tel:`, third-party app deep links).

## Scope

- [ ] Backend (`backend/`)
- [ ] Web (`frontend/apps/web`)
- [x] Mobile (`frontend/apps/mobile`)
- [x] Shared packages / tooling / CI

Mobile only, apart from `packages/api/orval.config.ts` (enables infinite-query generation for `listAlumni`) and the lockfile.

## Acceptance criteria

- [x] Every acceptance criterion I ticked in the issue is really implemented on this branch

## Tests

- [ ] I added or updated automated tests for this change
- [ ] Existing tests still pass locally
- [x] No new tests