### PR TITLE
test(backend): add comprehensive unit and integration tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
 
       - id: errorprone
         name: Error Prone (Java)
-        entry: bash -c 'cd backend && ./gradlew compileJava -Pstrict --daemon'
+        entry: bash -c 'cd backend && ./gradlew compileJava compileTestJava -Pstrict --daemon'
         language: system
         files: ^backend/.*\.java$
         pass_filenames: false

--- a/backend/src/test/java/pl/edu/agh/backend/alumni/AlumniServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/alumni/AlumniServiceTest.java
@@ -1,0 +1,67 @@
+package pl.edu.agh.backend.alumni;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import pl.edu.agh.backend.application.ApplicationRepository;
+import pl.edu.agh.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AlumniServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @InjectMocks
+    private AlumniService alumniService;
+
+    @Test
+    void rejectsUnsupportedSortProperty() {
+        assertThatThrownBy(() ->
+                        alumniService.search(null, null, null, null, null, PageRequest.of(0, 20, Sort.by("email"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void clampsPageSizeToMax() {
+        when(userRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(org.springframework.data.domain.Page.empty());
+
+        alumniService.search(null, null, null, null, null, PageRequest.of(0, 500));
+
+        org.mockito.Mockito.verify(userRepository)
+                .findAll(
+                        any(Specification.class),
+                        org.mockito.ArgumentMatchers.argThat(
+                                (Pageable pageable) -> pageable.getPageSize() == AlumniService.MAX_PAGE_SIZE));
+    }
+
+    @Test
+    void getProfileThrowsWhenNoApprovedApplication() {
+        UUID id = UUID.randomUUID();
+        when(userRepository.findWithTagsById(id)).thenReturn(java.util.Optional.of(new pl.edu.agh.backend.user.User()));
+        when(applicationRepository.findFirstByApplicantIdAndStatusOrderByReviewedAtDesc(
+                        id, pl.edu.agh.backend.application.ApplicationStatus.APPROVED))
+                .thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> alumniService.getProfile(id)).isInstanceOf(AlumniNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationIntegrationTest.java
@@ -1,0 +1,172 @@
+package pl.edu.agh.backend.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.infrastructure.keycloak.KeycloakRoleService;
+import pl.edu.agh.backend.support.JwtTestSupport;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class AdminApplicationIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
+    @MockitoBean
+    private KeycloakRoleService keycloakRoleService;
+
+    private User applicant;
+    private User admin;
+    private Application pendingApplication;
+
+    @BeforeEach
+    void setUp() {
+        applicant = new User();
+        applicant.setKeycloakId(UUID.randomUUID().toString());
+        applicant.setEmail("applicant@example.com");
+        applicant = userRepository.save(applicant);
+
+        admin = new User();
+        admin.setKeycloakId(UUID.randomUUID().toString());
+        admin = userRepository.save(admin);
+
+        pendingApplication = Application.builder()
+                .applicant(applicant)
+                .faculty(Faculty.WI)
+                .fieldOfStudy("Informatyka")
+                .studyType(StudyType.MASTER)
+                .graduationYear(2019)
+                .phoneNumber("+48111222333")
+                .build();
+        pendingApplication.addConsent(ConsentType.REGULATIONS_PRIVACY, java.time.Instant.now());
+        pendingApplication.addConsent(ConsentType.GDPR_DATA_PROCESSING, java.time.Instant.now());
+        pendingApplication = applicationRepository.save(pendingApplication);
+    }
+
+    @Test
+    void listUnderReviewApplications() throws Exception {
+        mockMvc.perform(get("/api/admin/applications").with(JwtTestSupport.asAdmin(admin.getKeycloakId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.application.id=='%s')]".formatted(pendingApplication.getId()))
+                        .exists());
+    }
+
+    @Test
+    void getApplicationById() throws Exception {
+        mockMvc.perform(get("/api/admin/applications/{id}", pendingApplication.getId())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.application.id")
+                        .value(pendingApplication.getId().toString()))
+                .andExpect(jsonPath("$.applicantKeycloakId").value(applicant.getKeycloakId()))
+                .andExpect(jsonPath("$.application.status").value("UNDER_REVIEW"));
+    }
+
+    @Test
+    void getUnknownApplicationReturns404() throws Exception {
+        mockMvc.perform(get("/api/admin/applications/{id}", UUID.randomUUID())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId())))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void approveApplicationUpdatesStatusAndGraduationYear() throws Exception {
+        mockMvc.perform(post("/api/admin/applications/{id}/approve", pendingApplication.getId())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId()))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("APPROVED"))
+                .andExpect(jsonPath("$.reviewedAt").exists());
+
+        User updatedApplicant = userRepository.findById(applicant.getId()).orElseThrow();
+        assertThat(updatedApplicant.getGraduationYear()).isEqualTo(2019);
+    }
+
+    @Test
+    void rejectApplicationWithReason() throws Exception {
+        mockMvc.perform(post("/api/admin/applications/{id}/reject", pendingApplication.getId())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\": \"Missing proof of graduation\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.rejectionReason").value("Missing proof of graduation"));
+    }
+
+    @Test
+    void approveAlreadyApprovedReturns409() throws Exception {
+        pendingApplication.approve(admin);
+        applicationRepository.saveAndFlush(pendingApplication);
+
+        mockMvc.perform(post("/api/admin/applications/{id}/approve", pendingApplication.getId())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId()))
+                        .with(csrf()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void rejectAlreadyRejectedReturns409() throws Exception {
+        pendingApplication.reject(admin, "no");
+        applicationRepository.saveAndFlush(pendingApplication);
+
+        mockMvc.perform(post("/api/admin/applications/{id}/reject", pendingApplication.getId())
+                        .with(JwtTestSupport.asAdmin(admin.getKeycloakId()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void nonAdminCannotAccessAdminEndpoints() throws Exception {
+        mockMvc.perform(get("/api/admin/applications").with(JwtTestSupport.asUser()))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/admin/applications/{id}/approve", pendingApplication.getId())
+                        .with(JwtTestSupport.asUser(applicant.getKeycloakId()))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticatedAdminRequestReturns401() throws Exception {
+        mockMvc.perform(get("/api/admin/applications")).andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationServiceTest.java
@@ -63,6 +63,8 @@ class AdminApplicationServiceTest {
         assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
         assertThat(applicant.getGraduationYear()).isEqualTo(2020);
 
+        verify(userProvisioningService).provisionIfAbsent(any());
+
         ArgumentCaptor<ApplicationApprovedEvent> eventCaptor = ArgumentCaptor.forClass(ApplicationApprovedEvent.class);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().applicantKeycloakId()).isEqualTo("applicant-kc");

--- a/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/AdminApplicationServiceTest.java
@@ -1,0 +1,125 @@
+package pl.edu.agh.backend.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserPrincipalExtractor;
+import pl.edu.agh.backend.user.UserProvisioningService;
+import pl.edu.agh.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminApplicationServiceTest {
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserPrincipalExtractor principalExtractor;
+
+    @Mock
+    private UserProvisioningService userProvisioningService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private AdminApplicationService adminApplicationService;
+
+    @Test
+    void approvePublishesApplicationApprovedEvent() {
+        UUID applicationId = UUID.randomUUID();
+        User applicant = user("applicant-kc");
+        User reviewer = user("reviewer-kc");
+        Application application = pendingApplication(applicant);
+
+        when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+        when(principalExtractor.extract(any()))
+                .thenReturn(Optional.of(new UserPrincipalExtractor.UserPrincipalInfo(reviewer.getKeycloakId())));
+        when(userRepository.findByKeycloakId(reviewer.getKeycloakId())).thenReturn(Optional.of(reviewer));
+        when(applicationRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ApplicationResponse response =
+                adminApplicationService.approve(jwtAuth(reviewer.getKeycloakId()), applicationId);
+
+        assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
+        assertThat(applicant.getGraduationYear()).isEqualTo(2020);
+
+        ArgumentCaptor<ApplicationApprovedEvent> eventCaptor = ArgumentCaptor.forClass(ApplicationApprovedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().applicantKeycloakId()).isEqualTo("applicant-kc");
+    }
+
+    @Test
+    void rejectPersistsReasonWithoutPublishingApprovalEvent() {
+        UUID applicationId = UUID.randomUUID();
+        User applicant = user("applicant-kc");
+        User reviewer = user("reviewer-kc");
+        Application application = pendingApplication(applicant);
+
+        when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+        when(principalExtractor.extract(any()))
+                .thenReturn(Optional.of(new UserPrincipalExtractor.UserPrincipalInfo(reviewer.getKeycloakId())));
+        when(userRepository.findByKeycloakId(reviewer.getKeycloakId())).thenReturn(Optional.of(reviewer));
+        when(applicationRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ApplicationResponse response =
+                adminApplicationService.reject(jwtAuth(reviewer.getKeycloakId()), applicationId, "Incomplete docs");
+
+        assertThat(response.status()).isEqualTo(ApplicationStatus.REJECTED);
+        assertThat(response.rejectionReason()).isEqualTo("Incomplete docs");
+        verify(eventPublisher, org.mockito.Mockito.never()).publishEvent(any());
+    }
+
+    @Test
+    void getThrowsWhenApplicationMissing() {
+        UUID applicationId = UUID.randomUUID();
+        when(applicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminApplicationService.get(applicationId))
+                .isInstanceOf(ApplicationNotFoundException.class);
+    }
+
+    private static Application pendingApplication(User applicant) {
+        return Application.builder()
+                .applicant(applicant)
+                .faculty(Faculty.WI)
+                .fieldOfStudy("Informatyka")
+                .studyType(StudyType.MASTER)
+                .graduationYear(2020)
+                .phoneNumber("+48123456789")
+                .build();
+    }
+
+    private static User user(String keycloakId) {
+        User user = new User();
+        user.setKeycloakId(keycloakId);
+        return user;
+    }
+
+    private static JwtAuthenticationToken jwtAuth(String subject) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(subject)
+                .build();
+        return new JwtAuthenticationToken(jwt, List.of());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/ApplicationApprovedListenerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/ApplicationApprovedListenerTest.java
@@ -1,0 +1,50 @@
+package pl.edu.agh.backend.application;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import pl.edu.agh.backend.infrastructure.keycloak.KeycloakRoleAssignmentException;
+import pl.edu.agh.backend.infrastructure.keycloak.KeycloakRoleService;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationApprovedListenerTest {
+
+    @Mock
+    private KeycloakRoleService keycloakRoleService;
+
+    @InjectMocks
+    private ApplicationApprovedListener listener;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(listener, "verifiedAlumnRole", "verified-alumn");
+    }
+
+    @Test
+    void assignsVerifiedAlumnRoleOnApproval() {
+        listener.onApplicationApproved(new ApplicationApprovedEvent("kc-user-1"));
+
+        verify(keycloakRoleService).addRealmRole("kc-user-1", "verified-alumn");
+    }
+
+    @Test
+    void swallowsKeycloakFailureWithoutRethrowing() {
+        doThrow(new KeycloakRoleAssignmentException("fail", null))
+                .when(keycloakRoleService)
+                .addRealmRole(eq("kc-user-2"), eq("verified-alumn"));
+
+        listener.onApplicationApproved(new ApplicationApprovedEvent("kc-user-2"));
+
+        verify(keycloakRoleService).addRealmRole("kc-user-2", "verified-alumn");
+        verifyNoMoreInteractions(keycloakRoleService);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/ApplicationIntegrationTest.java
@@ -1,0 +1,164 @@
+package pl.edu.agh.backend.application;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.JwtTestSupport;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class ApplicationIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static String validApplicationBody() {
+        return """
+                {
+                  "faculty": "WI",
+                  "fieldOfStudy": "Informatyka",
+                  "studyType": "MASTER",
+                  "graduationYear": 2020,
+                  "phoneNumber": "+48123456789",
+                  "interests": ["backend"],
+                  "meetingPreferences": ["ONLINE"],
+                  "coCreationInterest": false,
+                  "newsletterSubscription": false,
+                  "consents": ["REGULATIONS_PRIVACY", "GDPR_DATA_PROCESSING"]
+                }
+                """;
+    }
+
+    @Test
+    void createApplicationReturns201() throws Exception {
+        String keycloakId = UUID.randomUUID().toString();
+
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser(keycloakId))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validApplicationBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("UNDER_REVIEW"))
+                .andExpect(jsonPath("$.fieldOfStudy").value("Informatyka"))
+                .andExpect(jsonPath("$.consents.length()").value(2));
+    }
+
+    @Test
+    void getMineReturnsLatestApplication() throws Exception {
+        String keycloakId = UUID.randomUUID().toString();
+
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser(keycloakId))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validApplicationBody()))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/applications/me").with(JwtTestSupport.asUser(keycloakId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UNDER_REVIEW"))
+                .andExpect(jsonPath("$.graduationYear").value(2020));
+    }
+
+    @Test
+    void getMineReturns404WhenNoApplication() throws Exception {
+        mockMvc.perform(get("/api/applications/me").with(JwtTestSupport.asUser()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void duplicateApplicationReturns409() throws Exception {
+        String keycloakId = UUID.randomUUID().toString();
+
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser(keycloakId))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validApplicationBody()))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser(keycloakId))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validApplicationBody()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void validationFailureReturns400() throws Exception {
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "faculty": "WI",
+                                  "fieldOfStudy": "",
+                                  "studyType": "MASTER",
+                                  "graduationYear": 2020,
+                                  "phoneNumber": "+48123456789",
+                                  "consents": ["REGULATIONS_PRIVACY", "GDPR_DATA_PROCESSING"]
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void missingRequiredConsentsReturns400() throws Exception {
+        mockMvc.perform(post("/api/applications")
+                        .with(JwtTestSupport.asUser())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "faculty": "WI",
+                                  "fieldOfStudy": "Informatyka",
+                                  "studyType": "MASTER",
+                                  "graduationYear": 2020,
+                                  "phoneNumber": "+48123456789",
+                                  "consents": ["REGULATIONS_PRIVACY"]
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void unauthenticatedCreateReturns401() throws Exception {
+        mockMvc.perform(post("/api/applications")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validApplicationBody()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticatedGetMineReturns401() throws Exception {
+        mockMvc.perform(get("/api/applications/me")).andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/ApplicationServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/ApplicationServiceTest.java
@@ -1,0 +1,143 @@
+package pl.edu.agh.backend.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserPrincipalExtractor;
+import pl.edu.agh.backend.user.UserProvisioningService;
+import pl.edu.agh.backend.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceTest {
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserPrincipalExtractor principalExtractor;
+
+    @Mock
+    private UserProvisioningService userProvisioningService;
+
+    @InjectMocks
+    private ApplicationService applicationService;
+
+    @Test
+    void createPersistsApplicationWithConsents() {
+        String keycloakId = UUID.randomUUID().toString();
+        User applicant = new User();
+        applicant.setKeycloakId(keycloakId);
+        var auth = jwtAuth(keycloakId);
+
+        when(principalExtractor.extract(auth))
+                .thenReturn(Optional.of(new UserPrincipalExtractor.UserPrincipalInfo(keycloakId)));
+        when(userRepository.findByKeycloakId(keycloakId)).thenReturn(Optional.of(applicant));
+        when(applicationRepository.existsByApplicantIdAndStatusIn(
+                        applicant.getId(), List.of(ApplicationStatus.UNDER_REVIEW, ApplicationStatus.APPROVED)))
+                .thenReturn(false);
+        when(applicationRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateApplicationRequest request = new CreateApplicationRequest(
+                Faculty.WI,
+                "Informatyka",
+                StudyType.MASTER,
+                2020,
+                Set.of("AI"),
+                EnumSet.of(MeetingPreference.ONLINE),
+                true,
+                false,
+                "+48123456789",
+                EnumSet.of(ConsentType.REGULATIONS_PRIVACY, ConsentType.GDPR_DATA_PROCESSING));
+
+        ApplicationResponse response = applicationService.create(auth, request);
+
+        assertThat(response.status()).isEqualTo(ApplicationStatus.UNDER_REVIEW);
+        assertThat(response.fieldOfStudy()).isEqualTo("Informatyka");
+        verify(userProvisioningService).provisionIfAbsent(new UserPrincipalExtractor.UserPrincipalInfo(keycloakId));
+    }
+
+    @Test
+    void createThrowsWhenBlockingApplicationExists() {
+        String keycloakId = UUID.randomUUID().toString();
+        User applicant = new User();
+        applicant.setKeycloakId(keycloakId);
+        var auth = jwtAuth(keycloakId);
+
+        when(principalExtractor.extract(auth))
+                .thenReturn(Optional.of(new UserPrincipalExtractor.UserPrincipalInfo(keycloakId)));
+        when(userRepository.findByKeycloakId(keycloakId)).thenReturn(Optional.of(applicant));
+        when(applicationRepository.existsByApplicantIdAndStatusIn(
+                        applicant.getId(), List.of(ApplicationStatus.UNDER_REVIEW, ApplicationStatus.APPROVED)))
+                .thenReturn(true);
+
+        CreateApplicationRequest request = new CreateApplicationRequest(
+                Faculty.WI,
+                "Informatyka",
+                StudyType.MASTER,
+                2020,
+                Set.of(),
+                EnumSet.noneOf(MeetingPreference.class),
+                false,
+                false,
+                "+48123456789",
+                EnumSet.of(ConsentType.REGULATIONS_PRIVACY, ConsentType.GDPR_DATA_PROCESSING));
+
+        assertThatThrownBy(() -> applicationService.create(auth, request))
+                .isInstanceOf(ApplicationAlreadyExistsException.class);
+        verify(applicationRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void getMineReturnsLatestApplication() {
+        String keycloakId = UUID.randomUUID().toString();
+        User applicant = new User();
+        applicant.setKeycloakId(keycloakId);
+        var auth = jwtAuth(keycloakId);
+        Application application = Application.builder()
+                .applicant(applicant)
+                .faculty(Faculty.WI)
+                .fieldOfStudy("Informatyka")
+                .studyType(StudyType.MASTER)
+                .graduationYear(2020)
+                .phoneNumber("+48123456789")
+                .build();
+
+        when(principalExtractor.extract(auth))
+                .thenReturn(Optional.of(new UserPrincipalExtractor.UserPrincipalInfo(keycloakId)));
+        when(userRepository.findByKeycloakId(keycloakId)).thenReturn(Optional.of(applicant));
+        when(applicationRepository.findFirstByApplicantIdOrderByCreatedAtDesc(applicant.getId()))
+                .thenReturn(Optional.of(application));
+
+        ApplicationResponse response = applicationService.getMine(auth);
+
+        assertThat(response.fieldOfStudy()).isEqualTo("Informatyka");
+    }
+
+    private static JwtAuthenticationToken jwtAuth(String subject) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(subject)
+                .build();
+        return new JwtAuthenticationToken(jwt, List.of());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/application/ApplicationStateTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/application/ApplicationStateTest.java
@@ -1,0 +1,84 @@
+package pl.edu.agh.backend.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import pl.edu.agh.backend.user.User;
+
+class ApplicationStateTest {
+
+    private User applicant;
+    private User reviewer;
+    private Application application;
+
+    @BeforeEach
+    void setUp() {
+        applicant = new User();
+        applicant.setKeycloakId(UUID.randomUUID().toString());
+
+        reviewer = new User();
+        reviewer.setKeycloakId(UUID.randomUUID().toString());
+
+        application = Application.builder()
+                .applicant(applicant)
+                .faculty(Faculty.WI)
+                .fieldOfStudy("Informatyka")
+                .studyType(StudyType.MASTER)
+                .graduationYear(2020)
+                .phoneNumber("+48123456789")
+                .build();
+    }
+
+    @Test
+    void approveTransitionsToApprovedAndDenormalizesGraduationYear() {
+        application.approve(reviewer);
+
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.APPROVED);
+        assertThat(application.getReviewedBy()).isEqualTo(reviewer);
+        assertThat(application.getReviewedAt()).isNotNull();
+        assertThat(application.getRejectionReason()).isNull();
+        assertThat(applicant.getGraduationYear()).isEqualTo(2020);
+    }
+
+    @Test
+    void rejectTransitionsToRejectedWithReason() {
+        application.reject(reviewer, "Incomplete documentation");
+
+        assertThat(application.getStatus()).isEqualTo(ApplicationStatus.REJECTED);
+        assertThat(application.getRejectionReason()).isEqualTo("Incomplete documentation");
+        assertThat(application.getReviewedBy()).isEqualTo(reviewer);
+        assertThat(application.getReviewedAt()).isNotNull();
+        assertThat(applicant.getGraduationYear()).isNull();
+    }
+
+    @Test
+    void approveOnAlreadyApprovedThrows() {
+        application.approve(reviewer);
+
+        assertThatThrownBy(() -> application.approve(reviewer))
+                .isInstanceOf(InvalidApplicationStateException.class)
+                .hasMessageContaining("already APPROVED");
+    }
+
+    @Test
+    void rejectOnAlreadyRejectedThrows() {
+        application.reject(reviewer, "reason");
+
+        assertThatThrownBy(() -> application.reject(reviewer, "again"))
+                .isInstanceOf(InvalidApplicationStateException.class)
+                .hasMessageContaining("already REJECTED");
+    }
+
+    @Test
+    void addConsentRecordsTypeAndTimestamp() {
+        var now = java.time.Instant.parse("2024-01-01T00:00:00Z");
+        application.addConsent(ConsentType.REGULATIONS_PRIVACY, now);
+
+        assertThat(application.getConsents()).hasSize(1);
+        assertThat(application.getConsents().getFirst().getType()).isEqualTo(ConsentType.REGULATIONS_PRIVACY);
+        assertThat(application.getConsents().getFirst().getGrantedAt()).isEqualTo(now);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/event/EventIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/event/EventIntegrationTest.java
@@ -1,0 +1,143 @@
+package pl.edu.agh.backend.event;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.JwtTestSupport;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class EventIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    private static final UUID PUBLIC_EVENT_ID = UUID.fromString("22222222-2222-2222-2222-222222222201");
+    private static final UUID ALUMNI_ONLY_EVENT_ID = UUID.fromString("22222222-2222-2222-2222-222222222202");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    private UUID pastEventId;
+
+    @BeforeEach
+    void setUp() {
+        Event past = Event.builder()
+                .title("Past event " + UUID.randomUUID())
+                .type(EventType.ONLINE)
+                .startsAt(Instant.parse("2020-01-01T10:00:00Z"))
+                .endsAt(Instant.parse("2020-01-01T12:00:00Z"))
+                .audience(Audience.PUBLIC)
+                .build();
+        pastEventId = eventRepository.save(past).getId();
+    }
+
+    @Test
+    void listUpcomingPublicEventsWithoutAuth() throws Exception {
+        mockMvc.perform(get("/api/public/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$.content[?(@.id=='%s')]".formatted(PUBLIC_EVENT_ID))
+                        .exists());
+    }
+
+    @Test
+    void anonymousUserDoesNotSeeAlumniOnlyEventsInList() throws Exception {
+        mockMvc.perform(get("/api/public/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id=='%s')]".formatted(ALUMNI_ONLY_EVENT_ID))
+                        .doesNotExist());
+    }
+
+    @Test
+    void verifiedAlumnSeesAlumniOnlyEvents() throws Exception {
+        mockMvc.perform(get("/api/public/events").with(JwtTestSupport.asVerifiedAlumn()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id=='%s')]".formatted(ALUMNI_ONLY_EVENT_ID))
+                        .exists());
+    }
+
+    @Test
+    void pastEventsAreExcludedFromList() throws Exception {
+        mockMvc.perform(get("/api/public/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id=='%s')]".formatted(pastEventId))
+                        .doesNotExist());
+    }
+
+    @Test
+    void getPublicEventByIdWithoutAuth() throws Exception {
+        mockMvc.perform(get("/api/public/events/{id}", PUBLIC_EVENT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.type").exists());
+    }
+
+    @Test
+    void anonymousUserGets404ForAlumniOnlyEvent() throws Exception {
+        mockMvc.perform(get("/api/public/events/{id}", ALUMNI_ONLY_EVENT_ID)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void verifiedAlumnCanAccessAlumniOnlyEvent() throws Exception {
+        mockMvc.perform(get("/api/public/events/{id}", ALUMNI_ONLY_EVENT_ID).with(JwtTestSupport.asVerifiedAlumn()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.audience").value("ALL_ALUMNI"));
+    }
+
+    @Test
+    void getUnknownEventReturns404() throws Exception {
+        mockMvc.perform(get("/api/public/events/{id}", UUID.randomUUID())).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void filterByTagName() throws Exception {
+        Tag aiTag = tagRepository.findAll().stream()
+                .filter(t -> "ai".equals(t.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        Event tagged = Event.builder()
+                .title("AI meetup " + UUID.randomUUID())
+                .type(EventType.ONLINE)
+                .startsAt(Instant.now().plusSeconds(86400 * 5))
+                .endsAt(Instant.now().plusSeconds(86400 * 5 + 7200))
+                .audience(Audience.PUBLIC)
+                .tags(Set.of(aiTag))
+                .build();
+        UUID taggedId = eventRepository.save(tagged).getId();
+
+        mockMvc.perform(get("/api/public/events").param("tags", "ai"))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.content[?(@.id=='%s')]".formatted(taggedId)).exists());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/event/EventServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/event/EventServiceTest.java
@@ -1,0 +1,87 @@
+package pl.edu.agh.backend.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Test
+    void listForAnonymousUserQueriesPublicAudienceOnly() {
+        Event publicEvent = Event.builder()
+                .title("Public")
+                .type(EventType.ONLINE)
+                .startsAt(Instant.now().plusSeconds(3600))
+                .endsAt(Instant.now().plusSeconds(7200))
+                .audience(Audience.PUBLIC)
+                .build();
+        when(eventRepository.findAll(any(Specification.class), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(publicEvent)));
+
+        var page = eventService.list(null, Set.of(), PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).hasSize(1);
+    }
+
+    @Test
+    void findByIdHidesAlumniOnlyEventFromAnonymousUser() {
+        UUID id = UUID.randomUUID();
+        Event alumniEvent = Event.builder()
+                .id(id)
+                .title("Alumni only")
+                .type(EventType.IN_PERSON)
+                .startsAt(Instant.now().plusSeconds(3600))
+                .endsAt(Instant.now().plusSeconds(7200))
+                .audience(Audience.ALL_ALUMNI)
+                .build();
+        when(eventRepository.findById(id)).thenReturn(java.util.Optional.of(alumniEvent));
+
+        assertThatThrownBy(() -> eventService.findById(id, null)).isInstanceOf(EventNotFoundException.class);
+    }
+
+    @Test
+    void findByIdAllowsVerifiedAlumnToSeeAlumniOnlyEvent() {
+        UUID id = UUID.randomUUID();
+        Event alumniEvent = Event.builder()
+                .id(id)
+                .title("Alumni only")
+                .type(EventType.IN_PERSON)
+                .startsAt(Instant.now().plusSeconds(3600))
+                .endsAt(Instant.now().plusSeconds(7200))
+                .audience(Audience.ALL_ALUMNI)
+                .build();
+        when(eventRepository.findById(id)).thenReturn(java.util.Optional.of(alumniEvent));
+
+        Jwt jwt =
+                Jwt.withTokenValue("token").header("alg", "none").subject("sub").build();
+        var auth = new JwtAuthenticationToken(jwt, List.of(new SimpleGrantedAuthority("ROLE_VERIFIED_ALUMN")));
+
+        Event found = eventService.findById(id, auth);
+
+        assertThat(found.getAudience()).isEqualTo(Audience.ALL_ALUMNI);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/event/TagCatalogIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/event/TagCatalogIntegrationTest.java
@@ -1,0 +1,62 @@
+package pl.edu.agh.backend.event;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.JwtTestSupport;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class TagCatalogIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void listEventTagsRequiresUserRole() throws Exception {
+        mockMvc.perform(get("/api/tags")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listEventTagsReturnsSortedCatalog() throws Exception {
+        mockMvc.perform(get("/api/tags").with(JwtTestSupport.asUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$[0].name").exists())
+                .andExpect(jsonPath("$[0].id").exists());
+    }
+
+    @Test
+    void listUserTagsRequiresUserRole() throws Exception {
+        mockMvc.perform(get("/api/user-tags")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listUserTagsReturnsSkillCatalog() throws Exception {
+        mockMvc.perform(get("/api/user-tags").with(JwtTestSupport.asUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$[0].name").exists());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/infrastructure/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/infrastructure/GlobalExceptionHandlerTest.java
@@ -1,0 +1,89 @@
+package pl.edu.agh.backend.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import pl.edu.agh.backend.alumni.AlumniNotFoundException;
+import pl.edu.agh.backend.application.ApplicationAlreadyExistsException;
+import pl.edu.agh.backend.application.ApplicationNotFoundException;
+import pl.edu.agh.backend.application.ApplicationStatus;
+import pl.edu.agh.backend.application.InvalidApplicationStateException;
+import pl.edu.agh.backend.event.EventNotFoundException;
+import pl.edu.agh.backend.infrastructure.keycloak.KeycloakRoleAssignmentException;
+
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void handleAlumniNotFoundReturns404() {
+        ProblemDetail detail = handler.handleAlumniNotFound(new AlumniNotFoundException(UUID.randomUUID()));
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(detail.getTitle()).isEqualTo("Alumni not found");
+    }
+
+    @Test
+    void handleEventNotFoundReturns404() {
+        ProblemDetail detail = handler.handleEventNotFound(new EventNotFoundException(UUID.randomUUID()));
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(detail.getTitle()).isEqualTo("Event not found");
+    }
+
+    @Test
+    void handleApplicationNotFoundReturns404() {
+        ProblemDetail detail = handler.handleApplicationNotFound(new ApplicationNotFoundException());
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(detail.getTitle()).isEqualTo("Application not found");
+    }
+
+    @Test
+    void handleApplicationAlreadyExistsReturns409() {
+        ProblemDetail detail = handler.handleApplicationAlreadyExists(new ApplicationAlreadyExistsException());
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(detail.getTitle()).isEqualTo("Application already exists");
+    }
+
+    @Test
+    void handleInvalidApplicationStateReturns409() {
+        ProblemDetail detail = handler.handleInvalidApplicationState(
+                new InvalidApplicationStateException(UUID.randomUUID(), ApplicationStatus.APPROVED));
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(detail.getTitle()).isEqualTo("Invalid application state");
+    }
+
+    @Test
+    void handleKeycloakRoleAssignmentReturns502() {
+        ProblemDetail detail =
+                handler.handleKeycloakRoleAssignment(new KeycloakRoleAssignmentException("failed", null));
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.BAD_GATEWAY.value());
+        assertThat(detail.getTitle()).isEqualTo("Identity provider error");
+    }
+
+    @Test
+    void handleValidationReturns400WithFieldErrors() throws NoSuchMethodException {
+        Object target = new Object();
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(target, "request");
+        binding.addError(new FieldError("request", "fieldOfStudy", "must not be blank"));
+        var ex = new MethodArgumentNotValidException(null, binding);
+
+        ProblemDetail detail = handler.handleValidation(ex);
+
+        assertThat(detail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(detail.getTitle()).isEqualTo("Validation failed");
+        @SuppressWarnings("unchecked")
+        var errors = (java.util.Map<String, String>) detail.getProperties().get("errors");
+        assertThat(errors).containsEntry("fieldOfStudy", "must not be blank");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/infrastructure/keycloak/KeycloakRoleServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/infrastructure/keycloak/KeycloakRoleServiceTest.java
@@ -1,0 +1,117 @@
+package pl.edu.agh.backend.infrastructure.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakRoleServiceTest {
+
+    @Mock
+    private Keycloak keycloakAdmin;
+
+    @InjectMocks
+    private KeycloakRoleService keycloakRoleService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(keycloakRoleService, "realm", "pkka");
+    }
+
+    @Test
+    void addRealmRoleAssignsWhenNotYetPresent() {
+        RealmResource realm = mock(RealmResource.class);
+        RolesResource roles = mock(RolesResource.class);
+        RoleResource roleResource = mock(RoleResource.class);
+        UsersResource users = mock(UsersResource.class);
+        UserResource userResource = mock(UserResource.class);
+        RoleMappingResource mappings = mock(RoleMappingResource.class);
+        var realmLevel = mock(org.keycloak.admin.client.resource.RoleScopeResource.class);
+
+        RoleRepresentation role = new RoleRepresentation();
+        role.setName("verified-alumn");
+
+        when(keycloakAdmin.realm("pkka")).thenReturn(realm);
+        when(realm.roles()).thenReturn(roles);
+        when(roles.get("verified-alumn")).thenReturn(roleResource);
+        when(roleResource.toRepresentation()).thenReturn(role);
+        when(realm.users()).thenReturn(users);
+        when(users.get("user-1")).thenReturn(userResource);
+        when(userResource.roles()).thenReturn(mappings);
+        when(mappings.realmLevel()).thenReturn(realmLevel);
+        when(realmLevel.listAll()).thenReturn(List.of());
+        doNothing().when(realmLevel).add(any());
+
+        keycloakRoleService.addRealmRole("user-1", "verified-alumn");
+
+        verify(realmLevel).add(List.of(role));
+    }
+
+    @Test
+    void addRealmRoleSkipsWhenAlreadyAssigned() {
+        RealmResource realm = mock(RealmResource.class);
+        RolesResource roles = mock(RolesResource.class);
+        RoleResource roleResource = mock(RoleResource.class);
+        UsersResource users = mock(UsersResource.class);
+        UserResource userResource = mock(UserResource.class);
+        RoleMappingResource mappings = mock(RoleMappingResource.class);
+        var realmLevel = mock(org.keycloak.admin.client.resource.RoleScopeResource.class);
+
+        RoleRepresentation existing = new RoleRepresentation();
+        existing.setName("verified-alumn");
+
+        when(keycloakAdmin.realm("pkka")).thenReturn(realm);
+        when(realm.roles()).thenReturn(roles);
+        when(roles.get("verified-alumn")).thenReturn(roleResource);
+        when(roleResource.toRepresentation()).thenReturn(existing);
+        when(realm.users()).thenReturn(users);
+        when(users.get("user-1")).thenReturn(userResource);
+        when(userResource.roles()).thenReturn(mappings);
+        when(mappings.realmLevel()).thenReturn(realmLevel);
+        when(realmLevel.listAll()).thenReturn(List.of(existing));
+
+        keycloakRoleService.addRealmRole("user-1", "verified-alumn");
+
+        verify(realmLevel, never()).add(any());
+    }
+
+    @Test
+    void addRealmRoleWrapsNotFoundException() {
+        when(keycloakAdmin.realm("pkka")).thenThrow(new NotFoundException());
+
+        assertThatThrownBy(() -> keycloakRoleService.addRealmRole("missing", "verified-alumn"))
+                .isInstanceOf(KeycloakRoleAssignmentException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void addRealmRoleWrapsRuntimeException() {
+        when(keycloakAdmin.realm("pkka")).thenThrow(new RuntimeException("network"));
+
+        assertThatThrownBy(() -> keycloakRoleService.addRealmRole("user-1", "verified-alumn"))
+                .isInstanceOf(KeycloakRoleAssignmentException.class)
+                .hasMessageContaining("Failed to assign");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/infrastructure/keycloak/KeycloakUserServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/infrastructure/keycloak/KeycloakUserServiceTest.java
@@ -1,0 +1,85 @@
+package pl.edu.agh.backend.infrastructure.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakUserServiceTest {
+
+    @Mock
+    private Keycloak keycloakAdmin;
+
+    @InjectMocks
+    private KeycloakUserService keycloakUserService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(keycloakUserService, "realm", "pkka");
+    }
+
+    @Test
+    void fetchDiscordIdReturnsDiscordProviderUserId() {
+        RealmResource realm = mock(RealmResource.class);
+        UsersResource users = mock(UsersResource.class);
+        UserResource userResource = mock(UserResource.class);
+
+        FederatedIdentityRepresentation discord = new FederatedIdentityRepresentation();
+        discord.setIdentityProvider("discord");
+        discord.setUserId("123456789012345678");
+
+        FederatedIdentityRepresentation google = new FederatedIdentityRepresentation();
+        google.setIdentityProvider("google");
+        google.setUserId("google-id");
+
+        when(keycloakAdmin.realm("pkka")).thenReturn(realm);
+        when(realm.users()).thenReturn(users);
+        when(users.get("kc-1")).thenReturn(userResource);
+        when(userResource.getFederatedIdentity()).thenReturn(List.of(google, discord));
+
+        assertThat(keycloakUserService.fetchDiscordId("kc-1")).contains("123456789012345678");
+    }
+
+    @Test
+    void fetchDiscordIdReturnsEmptyWhenUserNotFound() {
+        when(keycloakAdmin.realm("pkka")).thenThrow(new NotFoundException());
+
+        assertThat(keycloakUserService.fetchDiscordId("missing")).isEmpty();
+    }
+
+    @Test
+    void fetchDiscordIdReturnsEmptyOnRuntimeFailure() {
+        when(keycloakAdmin.realm("pkka")).thenThrow(new RuntimeException("timeout"));
+
+        assertThat(keycloakUserService.fetchDiscordId("kc-1")).isEmpty();
+    }
+
+    @Test
+    void fetchDiscordIdReturnsEmptyWhenNoDiscordLink() {
+        RealmResource realm = mock(RealmResource.class);
+        UsersResource users = mock(UsersResource.class);
+        UserResource userResource = mock(UserResource.class);
+
+        when(keycloakAdmin.realm("pkka")).thenReturn(realm);
+        when(realm.users()).thenReturn(users);
+        when(users.get("kc-1")).thenReturn(userResource);
+        when(userResource.getFederatedIdentity()).thenReturn(List.of());
+
+        assertThat(keycloakUserService.fetchDiscordId("kc-1")).isEmpty();
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/post/PostEntityTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/post/PostEntityTest.java
@@ -1,0 +1,63 @@
+package pl.edu.agh.backend.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import pl.edu.agh.backend.user.User;
+
+class PostEntityTest {
+
+    @Test
+    void prePersistGeneratesSlugFromTitle() {
+        Post post = new Post();
+        post.setTitle("Welcome to AGH Alumni!");
+        post.setContent("body");
+        post.setAuthor(new User());
+
+        post.onCreate();
+
+        assertThat(post.getSlug()).isEqualTo("welcome-to-agh-alumni");
+    }
+
+    @Test
+    void publishSetsStatusAndPublishedAtOnce() {
+        Post post = new Post();
+        post.setTitle("Draft");
+        post.setContent("body");
+        post.setAuthor(new User());
+
+        post.publish();
+
+        assertThat(post.getStatus()).isEqualTo(PostStatus.PUBLISHED);
+        assertThat(post.getPublishedAt()).isNotNull();
+    }
+
+    @Test
+    void republishDoesNotChangePublishedAt() {
+        Post post = new Post();
+        post.setTitle("Draft");
+        post.setContent("body");
+        post.setAuthor(new User());
+        post.publish();
+        Instant firstPublishedAt = post.getPublishedAt();
+
+        post.unpublish();
+        post.publish();
+
+        assertThat(post.getPublishedAt()).isEqualTo(firstPublishedAt);
+    }
+
+    @Test
+    void unpublishRevertsToDraft() {
+        Post post = new Post();
+        post.setTitle("Draft");
+        post.setContent("body");
+        post.setAuthor(new User());
+        post.publish();
+
+        post.unpublish();
+
+        assertThat(post.getStatus()).isEqualTo(PostStatus.DRAFT);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/post/PostIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/post/PostIntegrationTest.java
@@ -1,0 +1,107 @@
+package pl.edu.agh.backend.post;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class PostIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private String publishedSlug;
+    private String draftSlug;
+
+    @BeforeEach
+    void setUp() {
+        User author = userRepository.findAll().stream().findFirst().orElseGet(() -> {
+            User u = new User();
+            u.setKeycloakId(UUID.randomUUID().toString());
+            return userRepository.save(u);
+        });
+
+        Post published = new Post();
+        published.setTitle("Published post " + UUID.randomUUID());
+        published.setContent("Published content");
+        published.setAuthor(author);
+        published.publish();
+        publishedSlug = postRepository.save(published).getSlug();
+
+        Post draft = new Post();
+        draft.setTitle("Draft post " + UUID.randomUUID());
+        draft.setContent("Draft content");
+        draft.setAuthor(author);
+        draftSlug = postRepository.save(draft).getSlug();
+    }
+
+    @Test
+    void listPublishedPostsWithoutAuth() throws Exception {
+        mockMvc.perform(get("/api/public/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$.content[?(@.slug=='%s')]".formatted(publishedSlug))
+                        .exists())
+                .andExpect(jsonPath("$.content[?(@.slug=='%s')]".formatted(draftSlug))
+                        .doesNotExist());
+    }
+
+    @Test
+    void getPublishedPostBySlug() throws Exception {
+        mockMvc.perform(get("/api/public/posts/{slug}", publishedSlug))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value(publishedSlug))
+                .andExpect(jsonPath("$.content").value("Published content"));
+    }
+
+    @Test
+    void getDraftPostBySlugReturns404() throws Exception {
+        mockMvc.perform(get("/api/public/posts/{slug}", draftSlug)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getUnknownSlugReturns404() throws Exception {
+        mockMvc.perform(get("/api/public/posts/{slug}", "nonexistent-slug-" + UUID.randomUUID()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listPostsSupportsPagination() throws Exception {
+        mockMvc.perform(get("/api/public/posts").param("page", "0").param("size", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.size").value(1));
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/post/PostServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/post/PostServiceTest.java
@@ -1,0 +1,59 @@
+package pl.edu.agh.backend.post;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import pl.edu.agh.backend.user.User;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    @Test
+    void findAllPublishedMapsOnlyPublishedPosts() {
+        Post post = new Post();
+        post.setTitle("Hello");
+        post.setContent("Body");
+        post.setAuthor(new User());
+        post.publish();
+        when(postRepository.findAllByStatusOrderByPublishedAtDesc(PostStatus.PUBLISHED, PageRequest.of(0, 10)))
+                .thenReturn(new PageImpl<>(List.of(post)));
+
+        var page = postService.findAllPublished(PageRequest.of(0, 10));
+
+        org.assertj.core.api.Assertions.assertThat(page.getContent()).hasSize(1);
+        org.assertj.core.api.Assertions.assertThat(page.getContent().getFirst().title())
+                .isEqualTo("Hello");
+    }
+
+    @Test
+    void findPublishedBySlugThrowsWhenMissing() {
+        when(postRepository.findBySlugAndStatus("missing", PostStatus.PUBLISHED))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.findPublishedBySlug("missing"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    org.assertj.core.api.Assertions.assertThat(
+                                    rse.getStatusCode().value())
+                            .isEqualTo(HttpStatus.NOT_FOUND.value());
+                });
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/post/SlugUtilsTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/post/SlugUtilsTest.java
@@ -1,0 +1,32 @@
+package pl.edu.agh.backend.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SlugUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "'Welcome to AGH Alumni!', welcome-to-agh-alumni",
+        "'  Multiple   Spaces  ', multiple-spaces",
+        "'Special @#$ Characters!', special-characters",
+        "'Already-a-slug', already-a-slug",
+        "'Double--Dash', double-dash"
+    })
+    void toSlugNormalizesInput(String input, String expected) {
+        assertThat(SlugUtils.toSlug(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void toSlugStripsPolishDiacritics() {
+        assertThat(SlugUtils.toSlug("Kraków")).isEqualTo("krakow");
+    }
+
+    @Test
+    void toSlugHandlesEmptyAfterStripping() {
+        assertThat(SlugUtils.toSlug("!!!")).isEmpty();
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
@@ -1,0 +1,41 @@
+package pl.edu.agh.backend.security.config;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+class CsrfCookieFilterTest {
+
+    private final CsrfCookieFilter filter = new CsrfCookieFilter();
+
+    @Test
+    void rendersDeferredCsrfTokenBeforeContinuingChain() throws Exception {
+        CsrfToken token = new DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "token-value");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(CsrfToken.class.getName(), token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assert token.getToken().equals("token-value");
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void continuesChainWhenNoCsrfTokenPresent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
@@ -16,7 +16,7 @@ class CsrfCookieFilterTest {
 
     @Test
     void rendersDeferredCsrfTokenBeforeContinuingChain() throws Exception {
-        CsrfToken token = new DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "token-value");
+CsrfToken token = mock(CsrfToken.class);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setAttribute(CsrfToken.class.getName(), token);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -24,7 +24,7 @@ class CsrfCookieFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        assert token.getToken().equals("token-value");
+        verify(token).getToken();
         verify(chain).doFilter(request, response);
     }
 

--- a/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/config/CsrfCookieFilterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.security.web.csrf.DefaultCsrfToken;
 
 class CsrfCookieFilterTest {
 
@@ -16,7 +15,7 @@ class CsrfCookieFilterTest {
 
     @Test
     void rendersDeferredCsrfTokenBeforeContinuingChain() throws Exception {
-CsrfToken token = mock(CsrfToken.class);
+        CsrfToken token = mock(CsrfToken.class);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setAttribute(CsrfToken.class.getName(), token);
         MockHttpServletResponse response = new MockHttpServletResponse();

--- a/backend/src/test/java/pl/edu/agh/backend/security/config/SecurityConfigRolesTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/config/SecurityConfigRolesTest.java
@@ -1,0 +1,50 @@
+package pl.edu.agh.backend.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class SecurityConfigRolesTest {
+
+    @Test
+    void extractRealmRolesMapsDashToUnderscoreAndUppercases() {
+        Map<String, Object> claims = Map.of("realm_access", Map.of("roles", List.of("verified-alumn", "admin")));
+
+        Set<String> roles = SecurityConfig.extractRealmRoles(claims).stream()
+                .map(a -> a.getAuthority())
+                .collect(Collectors.toSet());
+
+        assertThat(roles).containsExactlyInAnyOrder("ROLE_VERIFIED_ALUMN", "ROLE_ADMIN");
+    }
+
+    @Test
+    void extractRealmRolesReturnsEmptyWhenClaimMissing() {
+        assertThat(SecurityConfig.extractRealmRoles(Map.of())).isEmpty();
+    }
+
+    @Test
+    void extractRealmRolesReturnsEmptyWhenRolesNull() {
+        Map<String, Object> claims = Map.of("realm_access", Map.of());
+        assertThat(SecurityConfig.extractRealmRoles(claims)).isEmpty();
+    }
+
+    @Test
+    void hasBearerTokenDetectsAuthorizationHeader() {
+        var request = org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+        org.mockito.Mockito.when(request.getHeader("Authorization")).thenReturn("Bearer abc");
+
+        assertThat(SecurityConfig.hasBearerToken(request)).isTrue();
+    }
+
+    @Test
+    void hasBearerTokenReturnsFalseWithoutBearer() {
+        var request = org.mockito.Mockito.mock(jakarta.servlet.http.HttpServletRequest.class);
+        org.mockito.Mockito.when(request.getHeader("Authorization")).thenReturn("Basic abc");
+
+        assertThat(SecurityConfig.hasBearerToken(request)).isFalse();
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/config/SpaCsrfTokenRequestHandlerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/config/SpaCsrfTokenRequestHandlerTest.java
@@ -1,0 +1,22 @@
+package pl.edu.agh.backend.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+class SpaCsrfTokenRequestHandlerTest {
+
+    private final SpaCsrfTokenRequestHandler handler = new SpaCsrfTokenRequestHandler();
+
+    @Test
+    void resolvesPlainHeaderValueWhenHeaderPresent() {
+        CsrfToken token = new DefaultCsrfToken("X-XSRF-TOKEN", "_csrf", "plain-token");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-XSRF-TOKEN", "plain-token");
+
+        assertThat(handler.resolveCsrfTokenValue(request, token)).isEqualTo("plain-token");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/controller/AuthRefreshControllerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/controller/AuthRefreshControllerTest.java
@@ -1,0 +1,142 @@
+package pl.edu.agh.backend.security.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AuthRefreshControllerTest {
+
+    private HttpServer server;
+    private MockMvc mockMvc;
+    private String tokenEndpoint;
+    private String logoutEndpoint;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = server.getAddress().getPort();
+        tokenEndpoint = "http://127.0.0.1:" + port + "/token";
+        logoutEndpoint = "http://127.0.0.1:" + port + "/logout";
+        server.start();
+
+        ClientRegistrationRepository repo = mock(ClientRegistrationRepository.class);
+        when(repo.findByRegistrationId("keycloak-mobile")).thenReturn(mobileRegistration());
+
+        mockMvc =
+                MockMvcBuilders.standaloneSetup(new AuthRefreshController(repo)).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void refreshReturnsNewTokensOnSuccess() throws Exception {
+        server.createContext("/token", exchange -> {
+            byte[] body = "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\"}"
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+
+        mockMvc.perform(post("/api/public/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"old-refresh\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").value("new-access"))
+                .andExpect(jsonPath("$.refresh_token").value("new-refresh"));
+    }
+
+    @Test
+    void refreshReturns401OnInvalidGrant() throws Exception {
+        server.createContext("/token", exchange -> {
+            byte[] body = "{\"error\":\"invalid_grant\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(400, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+
+        mockMvc.perform(post("/api/public/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"expired\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void refreshReturns502OnUpstreamError() throws Exception {
+        server.createContext("/token", exchange -> {
+            byte[] body = "{\"error\":\"invalid_client\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(400, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+
+        mockMvc.perform(post("/api/public/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"token\"}"))
+                .andExpect(status().is(502));
+    }
+
+    @Test
+    void refreshReturns400WhenTokenMissing() throws Exception {
+        mockMvc.perform(post("/api/public/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void logoutReturns204EvenWhenUpstreamReturns4xx() throws Exception {
+        server.createContext("/logout", exchange -> exchange.sendResponseHeaders(400, -1));
+
+        mockMvc.perform(post("/api/public/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"token\"}"))
+                .andExpect(status().isNoContent());
+    }
+
+    private ClientRegistration mobileRegistration() {
+        return ClientRegistration.withRegistrationId("keycloak-mobile")
+                .clientId("pkka-mobile")
+                .clientSecret("secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .issuerUri("http://127.0.0.1:8081/realms/pkka")
+                .authorizationUri("http://127.0.0.1:8081/auth")
+                .tokenUri(tokenEndpoint)
+                .userInfoUri("http://127.0.0.1:8081/userinfo")
+                .jwkSetUri("http://127.0.0.1:8081/jwks")
+                .providerConfigurationMetadata(Map.of("end_session_endpoint", logoutEndpoint))
+                .build();
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/controller/DebugTokenControllerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/controller/DebugTokenControllerTest.java
@@ -1,0 +1,96 @@
+package pl.edu.agh.backend.security.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+class DebugTokenControllerTest {
+
+    @Test
+    void debugTokenReturnsIdAccessAndRefreshTokens() {
+        OAuth2AuthorizedClientService clientService = mock(OAuth2AuthorizedClientService.class);
+        DebugTokenController controller = new DebugTokenController(clientService);
+
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token-value",
+                Instant.now(),
+                Instant.now().plusSeconds(3600),
+                Map.of("sub", "kc-1", "email", "dev@example.com"));
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        var oidcUser = new DefaultOidcUser(authorities, idToken);
+        var auth = new OAuth2AuthenticationToken(oidcUser, authorities, "keycloak-web");
+
+        OAuth2AuthorizedClient client = new OAuth2AuthorizedClient(
+                ClientRegistration.withRegistrationId("keycloak-web")
+                        .clientId("pkka-web")
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                        .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                        .authorizationUri("http://localhost/auth")
+                        .tokenUri("http://localhost/token")
+                        .issuerUri("http://localhost/realms/pkka")
+                        .build(),
+                auth.getName(),
+                new OAuth2AccessToken(
+                        OAuth2AccessToken.TokenType.BEARER,
+                        "access-token-value",
+                        Instant.now(),
+                        Instant.now().plusSeconds(3600)),
+                new OAuth2RefreshToken("refresh-token-value", Instant.now()));
+
+        when(clientService.loadAuthorizedClient("keycloak-web", auth.getName())).thenReturn(client);
+
+        ResponseEntity<List<Map<String, Object>>> response = controller.debugToken(auth);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(3);
+        assertThat(response.getBody().get(0).get("tokenType")).isEqualTo("id_token");
+        assertThat(response.getBody().get(1).get("accessToken")).isEqualTo("access-token-value");
+        assertThat(response.getBody().get(2).get("refreshToken")).isEqualTo("refresh-token-value");
+    }
+
+    @Test
+    void debugTokenReturns404WhenAuthorizedClientMissing() {
+        OAuth2AuthorizedClientService clientService = mock(OAuth2AuthorizedClientService.class);
+        DebugTokenController controller = new DebugTokenController(clientService);
+
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token-value", Instant.now(), Instant.now().plusSeconds(3600), Map.of("sub", "kc-1"));
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        var auth =
+                new OAuth2AuthenticationToken(new DefaultOidcUser(authorities, idToken), authorities, "keycloak-web");
+
+        when(clientService.loadAuthorizedClient("keycloak-web", auth.getName())).thenReturn(null);
+
+        ResponseEntity<List<Map<String, Object>>> response = controller.debugToken(auth);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void debugTokenReturns401WhenAuthenticationNull() {
+        DebugTokenController controller = new DebugTokenController(mock(OAuth2AuthorizedClientService.class));
+
+        ResponseEntity<List<Map<String, Object>>> response = controller.debugToken(null);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/controller/MeControllerIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/controller/MeControllerIntegrationTest.java
@@ -1,0 +1,68 @@
+package pl.edu.agh.backend.security.controller;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class MeControllerIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void meReturnsJwtClaimsAndStrippedRoles() throws Exception {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("kc-subject-42")
+                .claim("email", "user@example.com")
+                .claim("given_name", "Jan")
+                .claim("family_name", "Kowalski")
+                .claim("preferred_username", "jkowalski")
+                .build();
+
+        mockMvc.perform(get("/api/me")
+                        .with(SecurityMockMvcRequestPostProcessors.jwt()
+                                .jwt(jwt)
+                                .authorities(
+                                        new SimpleGrantedAuthority("ROLE_USER"),
+                                        new SimpleGrantedAuthority("ROLE_VERIFIED_ALUMN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sub").value("kc-subject-42"))
+                .andExpect(jsonPath("$.email").value("user@example.com"))
+                .andExpect(jsonPath("$.firstName").value("Jan"))
+                .andExpect(jsonPath("$.lastName").value("Kowalski"))
+                .andExpect(jsonPath("$.preferredUsername").value("jkowalski"))
+                .andExpect(jsonPath("$.roles", containsInAnyOrder("USER", "VERIFIED_ALUMN")));
+    }
+
+    @Test
+    void meRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/me")).andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/controller/MeControllerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/controller/MeControllerTest.java
@@ -1,0 +1,95 @@
+package pl.edu.agh.backend.security.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.server.ResponseStatusException;
+import pl.edu.agh.backend.security.controller.dto.MeResponse;
+
+/**
+ * Unit tests for {@link MeController#me(Authentication)} covering both authentication shapes used in
+ * production: web OIDC session ({@link OAuth2AuthenticationToken}) and mobile Bearer JWT
+ * ({@link JwtAuthenticationToken}). {@link MeControllerIntegrationTest} exercises only the JWT path
+ * via MockMvc.
+ */
+class MeControllerTest {
+
+    private final MeController controller = new MeController();
+
+    @Test
+    void meReturnsClaimsFromOidcSessionUser() {
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token",
+                Instant.now(),
+                Instant.now().plusSeconds(3600),
+                Map.of(
+                        "sub", "kc-web-1",
+                        "email", "web@example.com",
+                        "given_name", "Anna",
+                        "family_name", "Nowak",
+                        "preferred_username", "anowak"));
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        var oidcUser = new DefaultOidcUser(authorities, idToken);
+        var auth = new OAuth2AuthenticationToken(oidcUser, authorities, "keycloak-web");
+
+        MeResponse response = controller.me(auth);
+
+        assertThat(response.sub()).isEqualTo("kc-web-1");
+        assertThat(response.email()).isEqualTo("web@example.com");
+        assertThat(response.firstName()).isEqualTo("Anna");
+        assertThat(response.lastName()).isEqualTo("Nowak");
+        assertThat(response.preferredUsername()).isEqualTo("anowak");
+        assertThat(response.roles()).containsExactly("USER");
+    }
+
+    @Test
+    void meReturnsClaimsFromBearerJwt() {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("kc-mobile-1")
+                .claim("email", "mobile@example.com")
+                .claim("given_name", "Jan")
+                .claim("family_name", "Kowalski")
+                .claim("preferred_username", "jkowalski")
+                .build();
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_VERIFIED_ALUMN"));
+        var auth = new JwtAuthenticationToken(jwt, authorities);
+
+        MeResponse response = controller.me(auth);
+
+        assertThat(response.sub()).isEqualTo("kc-mobile-1");
+        assertThat(response.email()).isEqualTo("mobile@example.com");
+        assertThat(response.firstName()).isEqualTo("Jan");
+        assertThat(response.roles()).containsExactly("VERIFIED_ALUMN");
+    }
+
+    @Test
+    void meRejectsUnsupportedAuthenticationType() {
+        var auth = new UsernamePasswordAuthenticationToken("user", "pass");
+
+        assertThatThrownBy(() -> controller.me(auth))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void meRejectsNullAuthentication() {
+        assertThatThrownBy(() -> controller.me(null))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/controller/WebLogoutRedirectIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/controller/WebLogoutRedirectIntegrationTest.java
@@ -1,0 +1,43 @@
+package pl.edu.agh.backend.security.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class WebLogoutRedirectIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private org.springframework.test.web.servlet.MockMvc mockMvc;
+
+    @Value("${app.web.logout-redirect-url}")
+    private String logoutRedirectUrl;
+
+    @Test
+    void postLogoutRedirectsToConfiguredUrl() throws Exception {
+        mockMvc.perform(get("/api/public/auth/post-logout"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", logoutRedirectUrl));
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/handler/BffAuthenticationSuccessHandlerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/handler/BffAuthenticationSuccessHandlerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.servlet.http.HttpSession;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
@@ -69,7 +69,7 @@ class BffAuthenticationSuccessHandlerTest {
         OidcUser oidcUser = oidcUser("kc-mobile-user");
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak-mobile");
 
-        HttpSession session = request.getSession(true);
+        MockHttpSession session = (MockHttpSession) request.getSession(true);
         session.setAttribute("marker", "present");
 
         OAuth2AuthorizedClient client = mock(OAuth2AuthorizedClient.class);
@@ -89,6 +89,7 @@ class BffAuthenticationSuccessHandlerTest {
         assertThat(response.getRedirectedUrl()).contains("rt=");
         verify(authorizedClientService).removeAuthorizedClient("keycloak-mobile", auth.getName());
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(session.isInvalid()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/pl/edu/agh/backend/security/handler/BffAuthenticationSuccessHandlerTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/handler/BffAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,118 @@
+package pl.edu.agh.backend.security.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpSession;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import pl.edu.agh.backend.user.UserProvisioningService;
+
+@ExtendWith(MockitoExtension.class)
+class BffAuthenticationSuccessHandlerTest {
+
+    @Mock
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @Mock
+    private UserProvisioningService userProvisioningService;
+
+    @InjectMocks
+    private BffAuthenticationSuccessHandler handler;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(handler, "mobileDeepLinkScheme", "myapp");
+        ReflectionTestUtils.setField(handler, "webSuccessUrl", "http://localhost:3000/dashboard");
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void webLoginSyncsIdentityAndRedirectsToSuccessUrl() throws Exception {
+        OidcUser oidcUser = oidcUser("kc-web-user");
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak-web");
+
+        handler.onAuthenticationSuccess(request, response, auth);
+
+        verify(userProvisioningService).syncIdentityFromClaims("kc-web-user", "Jan", "Kowalski", "jan@example.com");
+        assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:3000/dashboard");
+    }
+
+    @Test
+    void mobileLoginRedirectsToDeepLinkWithTokensAndInvalidatesSession() throws Exception {
+        OidcUser oidcUser = oidcUser("kc-mobile-user");
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak-mobile");
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute("marker", "present");
+
+        OAuth2AuthorizedClient client = mock(OAuth2AuthorizedClient.class);
+        when(client.getAccessToken())
+                .thenReturn(new OAuth2AccessToken(
+                        OAuth2AccessToken.TokenType.BEARER,
+                        "access-token-value",
+                        Instant.now(),
+                        Instant.now().plusSeconds(3600)));
+        when(client.getRefreshToken()).thenReturn(new OAuth2RefreshToken("refresh-token-value", Instant.now()));
+        when(authorizedClientService.loadAuthorizedClient("keycloak-mobile", auth.getName()))
+                .thenReturn(client);
+
+        handler.onAuthenticationSuccess(request, response, auth);
+
+        assertThat(response.getRedirectedUrl()).startsWith("myapp:///login#at=");
+        assertThat(response.getRedirectedUrl()).contains("rt=");
+        verify(authorizedClientService).removeAuthorizedClient("keycloak-mobile", auth.getName());
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void mobileLoginReturns500WhenAuthorizedClientMissing() throws Exception {
+        OidcUser oidcUser = oidcUser("kc-mobile-user");
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak-mobile");
+        when(authorizedClientService.loadAuthorizedClient("keycloak-mobile", auth.getName()))
+                .thenReturn(null);
+
+        handler.onAuthenticationSuccess(request, response, auth);
+
+        assertThat(response.getStatus()).isEqualTo(500);
+    }
+
+    private static OidcUser oidcUser(String subject) {
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token",
+                Instant.now(),
+                Instant.now().plusSeconds(3600),
+                Map.of(
+                        "sub", subject,
+                        "email", "jan@example.com",
+                        "given_name", "Jan",
+                        "family_name", "Kowalski"));
+        return new DefaultOidcUser(List.of(), idToken);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/security/resolver/DiscordBypassRequestResolverTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/security/resolver/DiscordBypassRequestResolverTest.java
@@ -1,0 +1,56 @@
+package pl.edu.agh.backend.security.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+class DiscordBypassRequestResolverTest {
+
+    private OAuth2AuthorizationRequestResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        ClientRegistration registration = ClientRegistration.withRegistrationId("keycloak-web")
+                .clientId("pkka-web")
+                .clientSecret("secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .authorizationUri("http://localhost/auth")
+                .tokenUri("http://localhost/token")
+                .issuerUri("http://localhost/realms/pkka")
+                .build();
+        ClientRegistrationRepository repo = new InMemoryClientRegistrationRepository(registration);
+        resolver = new DiscordBypassRequestResolver().discordBypassResolver(repo);
+    }
+
+    @Test
+    void addsKeycloakIdpHintWhenDiscordRequested() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/keycloak-web");
+        request.setParameter("idp", "discord");
+
+        OAuth2AuthorizationRequest authRequest = resolver.resolve(request, "keycloak-web");
+
+        assertThat(authRequest).isNotNull();
+        assertThat(authRequest.getAdditionalParameters()).containsEntry("kc_idp_hint", "discord");
+    }
+
+    @Test
+    void leavesRequestUnchangedWithoutDiscordHint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/keycloak-web");
+
+        OAuth2AuthorizationRequest authRequest = resolver.resolve(request, "keycloak-web");
+
+        assertThat(authRequest).isNotNull();
+        assertThat(authRequest.getAdditionalParameters()).doesNotContainKey("kc_idp_hint");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/support/JwtTestSupport.java
+++ b/backend/src/test/java/pl/edu/agh/backend/support/JwtTestSupport.java
@@ -1,0 +1,36 @@
+package pl.edu.agh.backend.support;
+
+import java.util.UUID;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+public final class JwtTestSupport {
+
+    private JwtTestSupport() {}
+
+    public static RequestPostProcessor asUser(String keycloakId) {
+        return SecurityMockMvcRequestPostProcessors.jwt()
+                .jwt(jwt -> jwt.subject(keycloakId))
+                .authorities(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    public static RequestPostProcessor asUser() {
+        return asUser(UUID.randomUUID().toString());
+    }
+
+    public static RequestPostProcessor asVerifiedAlumn() {
+        return SecurityMockMvcRequestPostProcessors.jwt()
+                .authorities(new SimpleGrantedAuthority("ROLE_VERIFIED_ALUMN"));
+    }
+
+    public static RequestPostProcessor asAdmin(String keycloakId) {
+        return SecurityMockMvcRequestPostProcessors.jwt()
+                .jwt(jwt -> jwt.subject(keycloakId))
+                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
+    public static RequestPostProcessor asAdmin() {
+        return asAdmin(UUID.randomUUID().toString());
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/support/TestSecurityConfig.java
+++ b/backend/src/test/java/pl/edu/agh/backend/support/TestSecurityConfig.java
@@ -1,0 +1,22 @@
+package pl.edu.agh.backend.support;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    ClientRegistrationRepository clientRegistrationRepository() {
+        return mock(ClientRegistrationRepository.class);
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder() {
+        return mock(JwtDecoder.class);
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/user/UserPrincipalExtractorTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/UserPrincipalExtractorTest.java
@@ -1,0 +1,37 @@
+package pl.edu.agh.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class UserPrincipalExtractorTest {
+
+    private final UserPrincipalExtractor extractor = new UserPrincipalExtractor();
+
+    @Test
+    void extractsKeycloakIdFromJwtAuthentication() {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("kc-subject-123")
+                .build();
+        var auth = new JwtAuthenticationToken(jwt, List.of());
+
+        var info = extractor.extract(auth);
+
+        assertThat(info).isPresent();
+        assertThat(info.get().keycloakId()).isEqualTo("kc-subject-123");
+    }
+
+    @Test
+    void returnsEmptyForUnsupportedAuthentication() {
+        var auth = new UsernamePasswordAuthenticationToken("user", "pass");
+
+        var info = extractor.extract(auth);
+
+        assertThat(info).isEmpty();
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/user/UserPrincipalExtractorTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/UserPrincipalExtractorTest.java
@@ -2,9 +2,14 @@ package pl.edu.agh.backend.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
@@ -24,6 +29,19 @@ class UserPrincipalExtractorTest {
 
         assertThat(info).isPresent();
         assertThat(info.get().keycloakId()).isEqualTo("kc-subject-123");
+    }
+
+    @Test
+    void extractsKeycloakIdFromOidcSessionAuthentication() {
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token", Instant.now(), Instant.now().plusSeconds(3600), Map.of("sub", "kc-oidc-99"));
+        var oidcUser = new DefaultOidcUser(List.of(), idToken);
+        var auth = new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak-web");
+
+        var info = extractor.extract(auth);
+
+        assertThat(info).isPresent();
+        assertThat(info.get().keycloakId()).isEqualTo("kc-oidc-99");
     }
 
     @Test

--- a/backend/src/test/java/pl/edu/agh/backend/user/UserProvisioningServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/UserProvisioningServiceTest.java
@@ -1,0 +1,116 @@
+package pl.edu.agh.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import pl.edu.agh.backend.infrastructure.keycloak.KeycloakUserService;
+
+@ExtendWith(MockitoExtension.class)
+class UserProvisioningServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private KeycloakUserService keycloakUserService;
+
+    @InjectMocks
+    private UserProvisioningService provisioningService;
+
+    @Test
+    void provisionIfAbsentReturnsExistingUserWithoutCreating() {
+        User existing = new User();
+        existing.setKeycloakId("kc-1");
+        when(userRepository.findByKeycloakId("kc-1")).thenReturn(Optional.of(existing));
+
+        User result = provisioningService.provisionIfAbsent(new UserPrincipalExtractor.UserPrincipalInfo("kc-1"));
+
+        assertThat(result).isSameAs(existing);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void provisionIfAbsentCreatesUserWhenMissing() {
+        when(userRepository.findByKeycloakId("kc-new")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User result = provisioningService.provisionIfAbsent(new UserPrincipalExtractor.UserPrincipalInfo("kc-new"));
+
+        assertThat(result.getKeycloakId()).isEqualTo("kc-new");
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void provisionIfAbsentRecoversFromConcurrentInsertRace() {
+        User racedUser = new User();
+        racedUser.setKeycloakId("kc-race");
+
+        when(userRepository.findByKeycloakId("kc-race"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(racedUser));
+        when(userRepository.save(any(User.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        User result = provisioningService.provisionIfAbsent(new UserPrincipalExtractor.UserPrincipalInfo("kc-race"));
+
+        assertThat(result).isSameAs(racedUser);
+        verify(userRepository, times(2)).findByKeycloakId("kc-race");
+    }
+
+    @Test
+    void syncIdentityUpdatesChangedClaimsAndFetchesDiscordIdWhenMissing() {
+        User existing = new User();
+        existing.setKeycloakId("kc-1");
+        existing.setFirstName("Old");
+        existing.setLastName("Name");
+        existing.setEmail("old@example.com");
+        existing.setDiscordId(null);
+
+        when(userRepository.findByKeycloakId("kc-1")).thenReturn(Optional.of(existing));
+        when(keycloakUserService.fetchDiscordId("kc-1")).thenReturn(Optional.of("discord-123"));
+
+        provisioningService.syncIdentityFromClaims("kc-1", "New", "Name", "new@example.com");
+
+        assertThat(existing.getFirstName()).isEqualTo("New");
+        assertThat(existing.getLastName()).isEqualTo("Name");
+        assertThat(existing.getEmail()).isEqualTo("new@example.com");
+        assertThat(existing.getDiscordId()).isEqualTo("discord-123");
+    }
+
+    @Test
+    void syncIdentitySkipsDiscordFetchWhenAlreadyLinked() {
+        User existing = new User();
+        existing.setKeycloakId("kc-1");
+        existing.setDiscordId("already-linked");
+
+        when(userRepository.findByKeycloakId("kc-1")).thenReturn(Optional.of(existing));
+
+        provisioningService.syncIdentityFromClaims("kc-1", "First", "Last", "mail@example.com");
+
+        verify(keycloakUserService, never()).fetchDiscordId(any());
+        assertThat(existing.getDiscordId()).isEqualTo("already-linked");
+    }
+
+    @Test
+    void syncIdentityIgnoresNullClaimsAndCreatesUserWhenMissing() {
+        when(userRepository.findByKeycloakId("kc-new")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(keycloakUserService.fetchDiscordId("kc-new")).thenReturn(Optional.empty());
+
+        provisioningService.syncIdentityFromClaims("kc-new", null, null, null);
+
+        verify(userRepository).save(any(User.class));
+        verify(keycloakUserService).fetchDiscordId(eq("kc-new"));
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/user/UserSpecificationsTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/UserSpecificationsTest.java
@@ -1,0 +1,17 @@
+package pl.edu.agh.backend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UserSpecificationsTest {
+
+    @Test
+    void likePatternEscapesSqlWildcards() throws Exception {
+        var method = UserSpecifications.class.getDeclaredMethod("likePattern", String.class);
+        method.setAccessible(true);
+        String pattern = (String) method.invoke(null, "100%_done");
+
+        assertThat(pattern).isEqualTo("%100\\%\\_done%");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
@@ -65,7 +65,7 @@ class ProfileServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> {
                     ResponseStatusException rse = (ResponseStatusException) ex;
-assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
                 });
     }
 

--- a/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
@@ -65,7 +65,7 @@ class ProfileServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(ex -> {
                     ResponseStatusException rse = (ResponseStatusException) ex;
-                    assert rse.getStatusCode() == HttpStatus.BAD_REQUEST;
+assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
                 });
     }
 

--- a/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileServiceTest.java
@@ -1,0 +1,86 @@
+package pl.edu.agh.backend.user.profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import pl.edu.agh.backend.application.ApplicationRepository;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserRepository;
+import pl.edu.agh.backend.user.UserTag;
+import pl.edu.agh.backend.user.UserTagRepository;
+import pl.edu.agh.backend.user.profile.dto.UpdateProfileRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserTagRepository userTagRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    @Test
+    void updateProfileClearsBlankStrings() {
+        User user = new User();
+        user.setKeycloakId("kc-1");
+        user.setCompany("ACME");
+        when(userRepository.findWithTagsByKeycloakId("kc-1")).thenReturn(java.util.Optional.of(user));
+        when(applicationRepository.findFirstByApplicantIdAndStatusOrderByReviewedAtDesc(
+                        user.getId(), pl.edu.agh.backend.application.ApplicationStatus.APPROVED))
+                .thenReturn(java.util.Optional.empty());
+
+        var response =
+                profileService.updateProfile("kc-1", new UpdateProfileRequest(null, null, "", null, null, null, null));
+
+        assertThat(response.company()).isNull();
+        assertThat(user.getCompany()).isNull();
+    }
+
+    @Test
+    void updateTagsRejectsUnknownTagIds() {
+        User user = new User();
+        user.setKeycloakId("kc-1");
+        UUID tagId = UUID.randomUUID();
+        when(userRepository.findWithTagsByKeycloakId("kc-1")).thenReturn(java.util.Optional.of(user));
+        when(userTagRepository.findAllById(Set.of(tagId))).thenReturn(List.of());
+
+        assertThatThrownBy(() -> profileService.updateTags("kc-1", Set.of(tagId)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException rse = (ResponseStatusException) ex;
+                    assert rse.getStatusCode() == HttpStatus.BAD_REQUEST;
+                });
+    }
+
+    @Test
+    void updateTagsReplacesAssignedTags() {
+        User user = new User();
+        user.setKeycloakId("kc-1");
+        UserTag tag = UserTag.builder().name("Java").build();
+        tag.setId(UUID.randomUUID());
+        when(userRepository.findWithTagsByKeycloakId("kc-1")).thenReturn(java.util.Optional.of(user));
+        when(userTagRepository.findAllById(Set.of(tag.getId()))).thenReturn(List.of(tag));
+
+        var tags = profileService.updateTags("kc-1", Set.of(tag.getId()));
+
+        assertThat(tags).hasSize(1);
+        assertThat(tags.getFirst().name()).isEqualTo("Java");
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileTagsIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/agh/backend/user/profile/ProfileTagsIntegrationTest.java
@@ -1,0 +1,131 @@
+package pl.edu.agh.backend.user.profile;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pl.edu.agh.backend.application.Application;
+import pl.edu.agh.backend.application.ApplicationRepository;
+import pl.edu.agh.backend.application.ApplicationStatus;
+import pl.edu.agh.backend.application.Faculty;
+import pl.edu.agh.backend.application.StudyType;
+import pl.edu.agh.backend.support.JwtTestSupport;
+import pl.edu.agh.backend.support.TestSecurityConfig;
+import pl.edu.agh.backend.user.User;
+import pl.edu.agh.backend.user.UserRepository;
+import pl.edu.agh.backend.user.UserTagRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@Import(TestSecurityConfig.class)
+class ProfileTagsIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserTagRepository userTagRepository;
+
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
+    private User user;
+    private UUID tagId;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setKeycloakId(UUID.randomUUID().toString());
+        user.setFirstName("Anna");
+        user.setBio("Bio");
+        user = userRepository.save(user);
+
+        tagId = userTagRepository.findAll().getFirst().getId();
+
+        Application approved = Application.builder()
+                .applicant(user)
+                .status(ApplicationStatus.APPROVED)
+                .faculty(Faculty.WI)
+                .fieldOfStudy("Informatyka")
+                .studyType(StudyType.MASTER)
+                .graduationYear(2021)
+                .phoneNumber("+48123456789")
+                .reviewedAt(java.time.Instant.parse("2022-01-01T00:00:00Z"))
+                .build();
+        applicationRepository.save(approved);
+    }
+
+    @Test
+    void getMyProfileReturnsEducationFacts() throws Exception {
+        mockMvc.perform(get("/api/profiles/me").with(JwtTestSupport.asUser(user.getKeycloakId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Anna"))
+                .andExpect(jsonPath("$.graduationYear").value(2021))
+                .andExpect(jsonPath("$.fieldOfStudy").value("Informatyka"));
+    }
+
+    @Test
+    void getMyTagsReturnsEmptyInitially() throws Exception {
+        mockMvc.perform(get("/api/profiles/me/tags").with(JwtTestSupport.asUser(user.getKeycloakId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void updateMyTagsReplacesTagSet() throws Exception {
+        mockMvc.perform(put("/api/profiles/me/tags")
+                        .with(JwtTestSupport.asUser(user.getKeycloakId()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tagIds\": [\"%s\"]}".formatted(tagId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)));
+
+        mockMvc.perform(get("/api/profiles/me/tags").with(JwtTestSupport.asUser(user.getKeycloakId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)));
+    }
+
+    @Test
+    void updateMyTagsWithInvalidIdReturns400() throws Exception {
+        mockMvc.perform(put("/api/profiles/me/tags")
+                        .with(JwtTestSupport.asUser(user.getKeycloakId()))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"tagIds\": [\"%s\"]}".formatted(UUID.randomUUID())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void profileEndpointsRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/profiles/me")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/profiles/me/tags")).andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## What & why

Adds broad backend test coverage (unit + integration with Testcontainers) for applications workflow, admin review, events, posts, profiles/tags, auth endpoints, Keycloak adapters, and security handlers. Closes gaps where only alumni/profile endpoints were tested.

## Scope

- [x] Backend (`backend/`)
- [ ] Web (`frontend/apps/web`)
- [ ] Mobile (`frontend/apps/mobile`)
- [ ] Shared packages / tooling / CI

## Acceptance criteria

- [x] Missing backend unit and integration tests added across controllers, services, domain logic, exception handling, and security
- [x] Tests cover happy paths, error/edge cases, and authorization where relevant
- [x] Existing tests preserved; full suite passes locally with Docker
- [x] No JaCoCo or other coverage reporting tooling added

## Tests

- [x] I added or updated automated tests for this change
- [x] Existing tests still pass locally
- [ ] No new tests